### PR TITLE
Added option to set SonarQube's host

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@ class sonarqube (
   $group = 'sonar',
   $user_system = true,
   $service = 'sonar', $installroot = '/usr/local', $home = '/var/local/sonar',
+  $host = undef,
   $port = 9000, $download_url = 'http://dist.sonar.codehaus.org',
   $context_path = '/', $arch = '', $ldap = {}, $crowd = {},
   $jdbc = {

--- a/templates/sonar.properties.erb
+++ b/templates/sonar.properties.erb
@@ -13,7 +13,11 @@
 # These settings are ignored when the war file is deployed to a JEE server.
 #---------------------------------------------------------
 # Listen host/port and context path (for example / or /sonar). Default values are 0.0.0.0:9000/.
+<% if @host -%>
+sonar.web.host:                           <%= @host %>
+<% else -%>
 #sonar.web.host:                           0.0.0.0
+<% end -%>
 sonar.web.port:                           <%= @port %>
 <% if has_variable?('context_path') -%>
 sonar.web.context:                        <%= @context_path %>


### PR DESCRIPTION
I added the option to set SonarQube's host in the `sonar.properties` file as I wanted to run it behind a local nginx instance and bind to `localhost` instead of `0.0.0.0`. I'm no puppet guru (or should I say... master :-)) but I've attempted to ensure existing configurations won't be changed by this update by setting it to undef by default and checking for this in the template. If the user does not use the host property, the file will not change.

Please consider merging this. If you need some additional changes to accept it, just inform me and I'll do my best to patch up this pull request (using my limited puppet skills).
