### PR TITLE
Added support for turning off updatecenter and configuring http proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ or
       download_url => 'http://dist.sonar.codehaus.org',
       jdbc         => $jdbc,
       log_folder   => '/var/local/sonar/logs',
+      updatecenter => 'true,
+      http_proxy   => {
+      	host        => 'proxy.example.com',
+      	port        => '8080',
+      	ntlm_domain => '',
+      	user        => '',
+      	password    => '',
+      }
     }
 
 ## SonarQube Plugins

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -31,6 +31,8 @@ class sonarqube (
     password          => 'sonar',
   },
   $log_folder = '/var/local/sonar/logs',
+  $updatecenter = 'true',
+  $http_proxy = {},
   $profile = false) inherits sonarqube::params {
 
   Exec {

--- a/templates/sonar.properties.erb
+++ b/templates/sonar.properties.erb
@@ -117,22 +117,24 @@ sonar.jdbc.timeBetweenEvictionRunsMillis:  30000
 
 # The Update Center requires an internet connection to request http://update.sonarsource.org
 # It is activated by default:
-#sonar.updatecenter.activate=true
+sonar.updatecenter.activate=<%= @updatecenter %>
 
+<% if !@http_proxy.empty? -%>
 # HTTP proxy (default none)
-#http.proxyHost=
-#http.proxyPort=
+http.proxyHost=<%= @http_proxy['host'] %>
+http.proxyPort=<%= @http_proxy['port'] %>
 
 # NT domain name if NTLM proxy is used
-#http.auth.ntlm.domain=
+http.auth.ntlm.domain=<%= @http_proxy['ntlm_domain'] %>
+
+# proxy authentication. The 2 following properties are used for HTTP and SOCKS proxies.
+http.proxyUser=<%= @http_proxy['user'] %>
+http.proxyPassword=<%= @http_proxy['password'] %>
+<% end -%>
 
 # SOCKS proxy (default none)
 #socksProxyHost=
 #socksProxyPort=
-
-# proxy authentication. The 2 following properties are used for HTTP and SOCKS proxies.
-#http.proxyUser=
-#http.proxyPassword=
 
 #---------------------------------------------------------
 # NOTIFICATIONS


### PR DESCRIPTION
Added support for changing `sonarqube.properties` file with the following settings:
- sonar.updatecenter.activate
- http.proxyHost
- http.proxyPort
- http.auth.ntlm.domain
- http.proxyUser
- http.proxyPassword
