### PR TITLE
allow sonarqube::runner to install independent of sonarqube

### DIFF
--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -26,7 +26,6 @@ class sonarqube::runner (
     version      => $version,
     download_url => $download_url,
     installroot  => $installroot,
-    require      => Class[ 'sonarqube' ],
   } ->
   class { '::sonarqube::runner::config':
     package_name => $package_name,

--- a/manifests/runner/config.pp
+++ b/manifests/runner/config.pp
@@ -12,5 +12,6 @@ class sonarqube::runner::config (
   # Sonar Runner configuration file
   file { "${installroot}/${package_name}-${version}/conf/sonar-runner.properties":
     content => template('sonarqube/sonar-runner.properties.erb'),
+    require => Exec[unzip-sonar-runner],
   }
 }

--- a/manifests/runner/config.pp
+++ b/manifests/runner/config.pp
@@ -12,6 +12,5 @@ class sonarqube::runner::config (
   # Sonar Runner configuration file
   file { "${installroot}/${package_name}-${version}/conf/sonar-runner.properties":
     content => template('sonarqube/sonar-runner.properties.erb'),
-    require => Exec['untar'],
   }
 }

--- a/manifests/runner/config.pp
+++ b/manifests/runner/config.pp
@@ -12,6 +12,6 @@ class sonarqube::runner::config (
   # Sonar Runner configuration file
   file { "${installroot}/${package_name}-${version}/conf/sonar-runner.properties":
     content => template('sonarqube/sonar-runner.properties.erb'),
-    require => Exec[unzip-sonar-runner],
+    require => Exec['unzip-sonar-runner'],
   }
 }

--- a/manifests/runner/install.pp
+++ b/manifests/runner/install.pp
@@ -7,6 +7,13 @@ class sonarqube::runner::install (
 ) {
   include wget
 
+  if ! defined(Package[unzip]) {
+    package { 'unzip':
+      ensure => present,
+      before => Exec[unzip-sonar-runner]
+    }
+  }
+
   $tmpzip = "/usr/local/src/${package_name}-dist-${version}.zip"
 
   wget::fetch { 'download-sonar-runner':
@@ -26,7 +33,7 @@ class sonarqube::runner::install (
   exec { 'unzip-sonar-runner':
     command => "unzip -o ${tmpzip} -d ${installroot}",
     creates => "${installroot}/sonar-runner-${version}/bin",
-    require => Wget::Fetch['download-sonar-runner'],
+    require => [Package[unzip], Wget::Fetch['download-sonar-runner']],
   }
 
   # Sonar settings for terminal sessions.


### PR DESCRIPTION
I needed to be able to install the sonar runner on machines that should not be running sonar 