### PR TITLE
Puppetfile: Update Puppet Forge URL to use v3 API

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,4 +1,4 @@
-forge 'http://forge.puppetlabs.com'
+forge 'https://forgeapi.puppetlabs.com'
 
 mod 'puppetlabs/stdlib', '>=2.3.0'
 mod 'maestrodev/wget',   '>=0.0.1'


### PR DESCRIPTION
When running `rake spec_prep`, librarian-puppet complains

```
Replacing Puppet Forge API URL to use v3 https://forgeapi.puppetlabs.com. You should update your Puppetfile
Replacing Puppet Forge API URL to use v3 https://forgeapi.puppetlabs.com. You should update your Puppetfile
Replacing Puppet Forge API URL to use v3 https://forgeapi.puppetlabs.com. You should update your Puppetfile
Replacing Puppet Forge API URL to use v3 https://forgeapi.puppetlabs.com. You should update your Puppetfile
Replacing Puppet Forge API URL to use v3 https://forgeapi.puppetlabs.com. You should update your Puppetfile
```