### PR TITLE
Allow custom sonar.properties

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -137,22 +137,22 @@ class sonarqube (
   }
 
   # Sonar configuration files
-	if $config != undef {
-		file { "${installdir}/conf/sonar.properties":
-			source => $config,
-			require => Exec['untar'],
-			notify  => Service['sonarqube'],
-			mode    => '0600'
-		}
-	}
-	else {
-		file { "${installdir}/conf/sonar.properties":
-			content => template('sonarqube/sonar.properties.erb'),
-			require => Exec['untar'],
-			notify  => Service['sonarqube'],
-			mode    => '0600'
-		}
-	}
+  if $config != undef {
+    file { "${installdir}/conf/sonar.properties":
+      source => $config,
+      require => Exec['untar'],
+      notify  => Service['sonarqube'],
+      mode    => '0600'
+    }
+  }
+  else {
+    file { "${installdir}/conf/sonar.properties":
+      content => template('sonarqube/sonar.properties.erb'),
+      require => Exec['untar'],
+      notify  => Service['sonarqube'],
+      mode    => '0600'
+    }
+  }
 
   # The plugins directory. Useful to later reference it from the plugin definition
   file { $plugin_dir:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -139,7 +139,7 @@ class sonarqube (
   # Sonar configuration files
   if $config != undef {
     file { "${installdir}/conf/sonar.properties":
-      source => $config,
+      source  => $config,
       require => Exec['untar'],
       notify  => Service['sonarqube'],
       mode    => '0600'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -137,22 +137,22 @@ class sonarqube (
   }
 
   # Sonar configuration files
-  if $config != undef {
-    file { "${installdir}/conf/sonar.properties":
-       source => $config,
-       require => Exec['untar'],
-       notify  => Service['sonarqube'],
-       mode    => '0600'
-    }
-  }
-  else {
-    file { "${installdir}/conf/sonar.properties":
-      content => template('sonarqube/sonar.properties.erb'),
-      require => Exec['untar'],
-      notify  => Service['sonarqube'],
-      mode    => '0600'
-    }
-  }
+	if $config != undef {
+		file { "${installdir}/conf/sonar.properties":
+			source => $config,
+			require => Exec['untar'],
+			notify  => Service['sonarqube'],
+			mode    => '0600'
+		}
+	}
+	else {
+		file { "${installdir}/conf/sonar.properties":
+			content => template('sonarqube/sonar.properties.erb'),
+			require => Exec['untar'],
+			notify  => Service['sonarqube'],
+			mode    => '0600'
+		}
+	}
 
   # The plugins directory. Useful to later reference it from the plugin definition
   file { $plugin_dir:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,7 @@ class sonarqube (
   $http_proxy    = {},
   $profile       = false,
   $web_java_opts = undef,
+  $config        = undef,
 ) inherits sonarqube::params {
   Exec {
     path => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin'
@@ -136,7 +137,15 @@ class sonarqube (
   }
 
   # Sonar configuration files
-  if ! defined(File["${installdir}/conf/sonar.properties"]) {
+  if $config != undef {
+    file { "${installdir}/conf/sonar.properties":
+      source => $config,
+      require => Exec['untar'],
+      notify  => Service['sonarqube'],
+      mode    => '0600'
+    }
+  }
+  else {
     file { "${installdir}/conf/sonar.properties":
       content => template('sonarqube/sonar.properties.erb'),
       require => Exec['untar'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -139,10 +139,10 @@ class sonarqube (
   # Sonar configuration files
   if $config != undef {
     file { "${installdir}/conf/sonar.properties":
-      source => $config,
-      require => Exec['untar'],
-      notify  => Service['sonarqube'],
-      mode    => '0600'
+       source => $config,
+       require => Exec['untar'],
+       notify  => Service['sonarqube'],
+       mode    => '0600'
     }
   }
   else {


### PR DESCRIPTION
Fix to allow management of sonar.properties outside this module.