### PR TITLE
Remove support of old SonarQube versions (<4.0)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -52,12 +52,7 @@ class sonarqube (
   # wget from https://github.com/maestrodev/puppet-wget
   include wget
 
-  if versioncmp($version, '4.0') < 0 {
-    $package_name = 'sonar'
-  }
-  else {
-    $package_name = 'sonarqube'
-  }
+  $package_name = 'sonarqube'
 
   if $home != undef {
     $real_home = $home

--- a/spec/acceptance/sonarqube_system_spec.rb
+++ b/spec/acceptance/sonarqube_system_spec.rb
@@ -31,7 +31,7 @@ describe 'sonarqube' do
   end
 
   context 'when installing version 4' do
-    let(:version) { '4.1.2' }
+    let(:version) { '4.5.4' }
 
     it_should_behave_like :sonar
 
@@ -55,16 +55,6 @@ describe 'sonarqube' do
 
       it { file("#{installroot}/conf/sonar.properties").content.should match(%r{^sonar.security.localUsers=foo,bar}) }
     end
-  end
-
-  context 'when installing version 3' do
-    let(:version) { '3.7.4' }
-
-    before(:all) do
-      on(hosts, "service sonar stop && rm -rf /etc/init.d/sonar* #{installroot}* #{home}*")
-    end
-
-    it_should_behave_like :sonar
   end
 
 end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -4,14 +4,9 @@ describe 'sonarqube' do
 
   let(:sonar_properties) { '/usr/local/sonar/conf/sonar.properties' }
 
-  context "when installing version 3", :compile do
-    let(:params) {{ :version => '3.7.4' }}
-    it { should contain_wget__fetch('download-sonar').with_source('http://downloads.sonarsource.com/sonarqube/sonar-3.7.4.zip') }
-  end
-
   context "when installing version 4", :compile do
-    let(:params) {{ :version => '4.1.2' }}
-    it { should contain_wget__fetch('download-sonar').with_source('http://downloads.sonarsource.com/sonarqube/sonarqube-4.1.2.zip') }
+    let(:params) {{ :version => '4.5.4' }}
+    it { should contain_wget__fetch('download-sonar').with_source('http://downloads.sonarsource.com/sonarqube/sonarqube-4.5.4.zip') }
   end
 
   context "when crowd configuration is supplied", :compile do


### PR DESCRIPTION
Remove support of old SonarQube versions (<4.0). They are more than two years old and no longer supported. Removes code to ease maintenance.