### PR TITLE
Remove old plugin versions because SonarQube does not support two dif…

### DIFF
--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -36,6 +36,11 @@ define sonarqube::plugin(
       before     => File[$plugin],
       require    => File[$sonarqube::plugin_dir],
     }
+    exec { "remove-old-versions-of-${artifactid}":
+      command => "rm -f ${sonarqube::plugin_dir}/${artifactid}*.jar",
+      path    => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
+    }
+    ->
     file { $plugin:
       ensure => $ensure,
       source => "/tmp/${plugin_name}",


### PR DESCRIPTION
…ferent versions of the same plugin in the extensions/plugins folder