### PR TITLE
Fixed the permissions ERRORS while execute cleanup-old-sonarqube-vers…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -172,7 +172,7 @@ class sonarqube (
   }
   ->
   exec { 'remove-old-versions-of-sonarqube':
-    command => "/tmp/cleanup-old-sonarqube-versions.sh ${installroot} ${version}",
+    command => "bash /tmp/cleanup-old-sonarqube-versions.sh ${installroot} ${version}",
     path    => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
   }
 


### PR DESCRIPTION
…ion during puppet-RUN

Error: '/tmp/cleanup-old-sonarqube-versions.sh' is not executable
Error: /Stage[main]/Sonarqube/Exec[remove-old-versions-of-sonarqube]/returns: change from notrun to 0 failed: '/tmp/cleanup-old-sonarqube-versions.sh' is not executable