### PR TITLE
Update metadata to Puppet Forge quality standards

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,7 +3,7 @@
   "version": "2.6.6",
   "author": "maestrodev",
   "summary": "SonarQube installation and configuration",
-  "license": "Apache License, Version 2.0",
+  "license": "Apache-2.0",
   "source": "http://github.com/maestrodev/puppet-sonarqube",
   "project_page": "http://github.com/maestrodev/puppet-sonarqube",
   "issues_url": "https://github.com/maestrodev/puppet-sonarqube/issues",
@@ -11,15 +11,15 @@
   "dependencies": [
     {
       "name": "maestrodev/wget",
-      "version_requirement": ">=0.0.1"
+      "version_requirement": ">=0.0.1 <2.0.0"
     },
     {
       "name": "maestrodev/maven",
-      "version_requirement": ">=0.0.2"
+      "version_requirement": ">=0.0.2 <2.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">=2.3.0"
+      "version_requirement": ">=2.3.0 <5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Brings the following fields in-line with Puppetlabs' `metadata.json` quality guidelines:
- license: License name should match an SPDX identifier
- dependencies: Should contain bounded ranges