### PR TITLE
trigger exec only when we have an other version

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -172,8 +172,10 @@ class sonarqube (
   }
   ->
   exec { 'remove-old-versions-of-sonarqube':
-    command => "/tmp/cleanup-old-sonarqube-versions.sh ${installroot} ${version}",
-    path    => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
+    command     => "/tmp/cleanup-old-sonarqube-versions.sh ${installroot} ${version}",
+    path        => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
+    refreshonly => true,
+    subscribe   => File["${installroot}/${package_name}-${version}"],
   }
 
   # The plugins directory. Useful to later reference it from the plugin definition

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -36,10 +36,11 @@ define sonarqube::plugin(
       before     => File[$plugin],
       require    => File[$sonarqube::plugin_dir],
     }
-    ->
+    ~>
     exec { "remove-old-versions-of-${artifactid}":
-      command => "/tmp/cleanup-old-plugin-versions.sh ${sonarqube::plugin_dir} ${artifactid} ${version}",
-      path    => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
+      command     => "/tmp/cleanup-old-plugin-versions.sh ${sonarqube::plugin_dir} ${artifactid} ${version}",
+      path        => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
+      refreshonly => true,
     }
     ->
     file { $plugin:


### PR DESCRIPTION
Hi,
we should only trigger cleanup execs if something has change

I think this should close this issue https://github.com/maestrodev/puppet-sonarqube/issues/48

Greetings Reamer