### PR TITLE
Add `plugins` parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ The `sonarqube::plugin` defined type can also be used to install SonarQube plugi
       groupid    => 'org.codehaus.sonar-plugins',
       artifactid => 'sonar-twitter-plugin',
       version    => '0.1',
-      notify     => Service['sonar'],
+      notify     => Service['sonarqube'],
     }
     
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ The `sonarqube::plugin` defined type can also be used to install SonarQube plugi
       groupid    => 'org.codehaus.sonar-plugins',
       artifactid => 'sonar-twitter-plugin',
       version    => '0.1',
-      notify     => Service['sonarqube'],
     }
     
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,6 +49,7 @@ class sonarqube (
   $web_java_opts    = undef,
   $search_java_opts = undef,
   $config           = undef,
+  $use_hiera        = false,
 ) inherits sonarqube::params {
   validate_absolute_path($download_dir)
   Exec {
@@ -207,6 +208,10 @@ class sonarqube (
     },
     artifactid => 'sonar-crowd-plugin',
     version    => '1.0',
+  }
+
+  if $use_hiera {
+    create_resources('sonarqube::plugin', hiera_hash('sonarqube::plugin', {}))
   }
 
   service { 'sonarqube':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,7 +49,7 @@ class sonarqube (
   $web_java_opts    = undef,
   $search_java_opts = undef,
   $config           = undef,
-  $use_hiera        = false,
+  $plugins          = {},
 ) inherits sonarqube::params {
   validate_absolute_path($download_dir)
   Exec {
@@ -210,9 +210,7 @@ class sonarqube (
     version    => '1.0',
   }
 
-  if $use_hiera {
-    create_resources('sonarqube::plugin', hiera_hash('sonarqube::plugin', {}))
-  }
+  create_resources('sonarqube::plugin', $plugins)
 
   service { 'sonarqube':
     ensure     => running,


### PR DESCRIPTION
...which is even more elegant I must say.

But in the end, I think I won't be using it though, as most plugins are either unavailable from the default maven repo (https://repo.maven.apache.org/maven2) or outdated.
So I guess I'll just follow the [recommended manual install](http://docs.sonarqube.org/display/SONAR/Installing+a+Plugin).