### PR TITLE
Default to download from BinTray

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ or
       service       => 'sonar',
       installroot   => '/usr/local',
       home          => '/var/local/sonar',
-      download_url  => 'http://downloads.sonarsource.com/sonarqube',
+      download_url  => 'https://sonarsource.bintray.com/Distribution/sonarqube'
       jdbc          => $jdbc,
       web_java_opts => '-Xmx1024m',
       log_folder    => '/var/local/sonar/logs',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,8 +22,7 @@ class sonarqube (
   $host             = undef,
   $port             = 9000,
   $portAjp          = -1,
-  # For version greater or equals to 5.2, $download_url must be set to 'https://sonarsource.bintray.com/Distribution/sonarqube'
-  $download_url     = 'http://downloads.sonarsource.com/sonarqube',
+  $download_url     = 'https://sonarsource.bintray.com/Distribution/sonarqube',
   $download_dir     = '/usr/local/src',
   $context_path     = '/',
   $arch             = $sonarqube::params::arch,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -6,7 +6,7 @@ describe 'sonarqube' do
 
   context "when installing version 4", :compile do
     let(:params) {{ :version => '4.5.5' }}
-    it { should contain_wget__fetch('download-sonar').with_source('http://downloads.sonarsource.com/sonarqube/sonarqube-4.5.5.zip') }
+    it { should contain_wget__fetch('download-sonar').with_source('https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-4.5.5.zip') }
   end
 
   context "when crowd configuration is supplied", :compile do


### PR DESCRIPTION
According to data on Bintray, SonarQube has been using Bintray since June, 2015.
Bintray provides all the versions of SonarQube including 4.5.6 and newer releases.