### PR TITLE
Do not automatically add LDAP, Crowd and PAM plugins while setting re…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -190,34 +190,6 @@ class sonarqube (
     ensure => directory,
   }
 
-  # For convenience, provide "built-in" support for the Sonar LDAP plugin.
-  sonarqube::plugin { 'sonar-ldap-plugin' :
-    ensure     => empty($ldap) ? {
-      true  => absent,
-      false => present,
-    },
-    artifactid => 'sonar-ldap-plugin',
-    version    => '1.4',
-  }
-
-  sonarqube::plugin { 'sonar-pam-plugin' :
-    ensure     => empty($pam) ? {
-      true  => absent,
-      false => present,
-    },
-    artifactid => 'sonar-pam-plugin',
-    version    => '0.2',
-  }
-
-  sonarqube::plugin { 'sonar-crowd-plugin' :
-    ensure     => empty($crowd) ? {
-      true  => absent,
-      false => present,
-    },
-    artifactid => 'sonar-crowd-plugin',
-    version    => '1.0',
-  }
-
   service { 'sonarqube':
     ensure     => running,
     name       => $service,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -16,8 +16,6 @@ describe 'sonarqube' do
       'password'    => 'crowdpassword',
     } } }
 
-    it { should contain_sonarqube__plugin('sonar-crowd-plugin').with_ensure('present') }
-
     it 'should generate sonar.properties config for crowd' do
       should contain_file(sonar_properties).with_content(%r[sonar\.authenticator\.class: org\.sonar\.plugins\.crowd\.CrowdAuthenticator])
       should contain_file(sonar_properties).with_content(%r[crowd\.url: crowdserviceurl])
@@ -27,7 +25,6 @@ describe 'sonarqube' do
   end
 
   context "when no crowd configuration is supplied", :compile do
-    it { should contain_sonarqube__plugin('sonar-crowd-plugin').with_ensure('absent') }
     it { should contain_file(sonar_properties).without_content("crowd") }
   end
 
@@ -50,7 +47,6 @@ describe 'sonarqube' do
       'local_users'  => 'foo',
     } } }
 
-    it { should contain_sonarqube__plugin('sonar-ldap-plugin').with_ensure('present')}
     it { should contain_file(sonar_properties).with_content(/sonar.security.localUsers=foo/) }
     it { should contain_file(sonar_properties).with_content(/sonar.security.realm=LDAP/) }
     it { should contain_file(sonar_properties).with_content(/ldap.url=ldap:\/\/myserver.mycompany.com/) }
@@ -64,7 +60,6 @@ describe 'sonarqube' do
       'local_users' => ['foo','bar'],
     } } }
 
-    it { should contain_sonarqube__plugin('sonar-ldap-plugin').with_ensure('present')}
     it { should contain_file(sonar_properties).with_content(/sonar.security.localUsers=foo,bar/) }
     it { should contain_file(sonar_properties).with_content(/sonar.security.realm=LDAP/) }
     it { should contain_file(sonar_properties).with_content(/ldap.url=ldap:\/\/myserver.mycompany.com/) }
@@ -76,7 +71,6 @@ describe 'sonarqube' do
       'url'          => 'ldap://myserver.mycompany.com',
       'user_base_dn' => 'ou=Users,dc=mycompany,dc=com',
     } } }
-    it { should contain_sonarqube__plugin('sonar-ldap-plugin').with_ensure('present')}
     it { should contain_file(sonar_properties).without_content(/sonar.security.localUsers/) }
     it { should contain_file(sonar_properties).with_content(/sonar.security.realm=LDAP/) }
     it { should contain_file(sonar_properties).with_content(/ldap.url=ldap:\/\/myserver.mycompany.com/) }
@@ -84,7 +78,6 @@ describe 'sonarqube' do
   end
 
   context "when no ldap configuration is supplied", :compile do
-    it { should contain_sonarqube__plugin('sonar-ldap-plugin').with_ensure('absent')}
     it { should contain_file(sonar_properties).without_content(/sonar.security/) }
     it { should contain_file(sonar_properties).without_content(/ldap./) }
   end


### PR DESCRIPTION
…lated configuration because it prevents setting default groupId/artifactId/version for those plugins.