### PR TITLE
Add ability to specify plugins using hiera data and automatically map them to the plugin call

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ The `sonarqube::plugin` defined type can be used to install SonarQube plugins. N
       version    => '2.10',
       notify     => Service['sonar'],
     }
+
+Plugins can also be installed in bulk using hiera:
+
+    ---
+    sonarqube::params::plugins:
+      sonar-findbugs-plugin:
+        version: 3.3
+      sonar-javascript-plugin:
+        version: 2.11
+        groupid: org.sonarsource.javascript
+
+And called in puppet using the same defined type, making sure you `include sonarqube::params`
+
+    sonarqube::plugin { $sonarqube::params::plugins: }
     
 
 ## Security Configuration

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,5 @@
 # Class: sonarqube::params
-class sonarqube::params ($plugins) {
+class sonarqube::params ($plugins={}) {
 
   # calculate in what folder is the binary to use for this architecture
   $arch1 = $::kernel ? {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,5 @@
 # Class: sonarqube::params
-class sonarqube::params {
+class sonarqube::params ($plugins) {
 
   # calculate in what folder is the binary to use for this architecture
   $arch1 = $::kernel ? {


### PR DESCRIPTION
When installing multiple plugins, it's much easier and cleaner to manage their names, versions, etc in hiera than in the module (or wrapping it all in _another_ define type).
