### PR TITLE
Non Fixed Sonar Runner Path 

### DIFF
--- a/manifests/runner/install.pp
+++ b/manifests/runner/install.pp
@@ -38,10 +38,10 @@ class sonarqube::runner::install (
 
   # Sonar settings for terminal sessions.
   file { '/etc/profile.d/sonarhome.sh':
-    content => 'export SONAR_RUNNER_HOME=/usr/local/sonar-runner',
+    content => "export SONAR_RUNNER_HOME=${installroot}/${package_name}-${version}",
   }
   file { '/usr/bin/sonar-runner':
     ensure => link,
-    target => '/var/lib/sonar-runner/bin/sonar-runner',
+    target => "${installroot}/${package_name}-${version}/bin/sonar-runner",
   }
 }


### PR DESCRIPTION
Uses project variables to configure runner installation path and runner home instead of fixed directories.

After this change sonar-runner will be available in the Linux $PATH.
