### PR TITLE
Add "data_dir" and "temp_dir" parameters to Sonarqube configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - rm -f Gemfile.lock
 
 rvm:
-  - "2.0.0"
+  - "2.2.5"
 
 env:
   - PUPPET_VERSION="~> 3.7.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - rm -f Gemfile.lock
 
 rvm:
-  - "2.2.5"
+  - "2.3.1"
 
 env:
   - PUPPET_VERSION="~> 3.7.0"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ env:
   - PUPPET_VERSION="~> 3.6.0"
   - PUPPET_VERSION="~> 3.5.0"
   - PUPPET_VERSION="~> 3.4.0"
-  - PUPPET_VERSION="~> 3.3.0"
-  - PUPPET_VERSION="~> 3.2.0"
 
 matrix:
   exclude:
@@ -38,6 +36,10 @@ matrix:
       env: PUPPET_VERSION="~> 3.3.0"
     - rvm: 2.1.0
       env: PUPPET_VERSION="~> 3.4.0"
+    - rvm: 2.1.0
+      env: PUPPET_VERSION="~> 3.2.0"
+    - rvm: 2.1.0
+      env: PUPPET_VERSION="~> 3.3.0"
 
 deploy:
   provider: puppetforge

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,6 @@ gem 'puppet-lint', '>= 1.1.0', :require => false
 gem 'simplecov', :require => false
 gem 'puppet-blacksmith', '>= 3.3.1', :require => false
 gem 'librarian-puppet', '>= 2.0.0', :require => false
-gem 'beaker', '>=2.50.0', :require => false
 gem 'beaker-rspec', '>= 3.0.0', :require => false
 
 # vim:ft=ruby

--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'puppet-lint', '>= 1.1.0', :require => false
 gem 'simplecov', :require => false
 gem 'puppet-blacksmith', '>= 3.3.1', :require => false
 gem 'librarian-puppet', '>= 2.0.0', :require => false
+gem 'beaker', '>=2.50.0', :require => false
 gem 'beaker-rspec', '>= 3.0.0', :require => false
 
 # vim:ft=ruby

--- a/Gemfile
+++ b/Gemfile
@@ -13,5 +13,6 @@ gem 'simplecov', :require => false
 gem 'puppet-blacksmith', '>= 3.3.1', :require => false
 gem 'librarian-puppet', '>= 2.0.0', :require => false
 gem 'beaker-rspec', '>= 3.0.0', :require => false
+gem 'safe_yaml', '~> 1.0.4'
 
 # vim:ft=ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
     aws-sdk-v1 (1.63.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-    beaker (2.4.1)
+    beaker (3.2.0)
       aws-sdk (~> 1.57)
       docker-api
       fission (~> 0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
     aws-sdk-v1 (1.63.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-    beaker (2.50.0)
+    beaker (2.4.1)
       aws-sdk (~> 1.57)
       docker-api
       fission (~> 0.4)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GEM
     aws-sdk-v1 (1.63.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-    beaker (3.2.0)
+    beaker (2.50.0)
       aws-sdk (~> 1.57)
       docker-api
       fission (~> 0.4)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,6 +53,10 @@ class sonarqube (
   $search_host      = '127.0.0.1',
   $search_port      = '9001',
   $config           = undef,
+  $path             = {
+    data_dir        => undef,
+    temp_dir        => undef,
+  },
 ) inherits sonarqube::params {
   validate_absolute_path($download_dir)
   Exec {
@@ -74,8 +78,8 @@ class sonarqube (
     $real_home = '/var/local/sonar'
   }
 
-  if $data_dir != undef {
-    $real_data_dir = $data_dir
+  if $path[data_dir] != undef {
+    $real_data_dir = $path[data_dir]
   } else {
     $real_data_dir = "${real_home}/data"
   }
@@ -140,7 +144,7 @@ class sonarqube (
     target => "${installroot}/${package_name}-${version}",
     notify => Service['sonarqube'],
   }
-  if $data_dir != undef {
+  if $path[data_dir] != undef {
     exec { 'create_data_dir':
       command => "mkdir -p ${real_data_dir}",
       creates => $real_data_dir,
@@ -153,14 +157,14 @@ class sonarqube (
       group  => $group,
     }
   }
-  if $temp_dir != undef {
+  if $path[temp_dir] != undef {
     exec { 'create_temp_dir':
-      command => "mkdir -p ${temp_dir}",
-      creates => $temp_dir,
+      command => "mkdir -p ${path[temp_dir]}",
+      creates => $path[temp_dir],
       require => File[$real_home],
     }
     ->
-    file { $temp_dir:
+    file { $path[temp_dir]:
       ensure => directory,
       owner  => $user,
       group  => $group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,7 @@ class sonarqube (
   $temp_dir         = undef,
   $host             = undef,
   $port             = 9000,
-  $portAjp          = -1,
+  $portajp          = -1,
   $download_url     = 'https://sonarsource.bintray.com/Distribution/sonarqube',
   $download_dir     = '/usr/local/src',
   $context_path     = '/',
@@ -195,7 +195,8 @@ class sonarqube (
   ->
   # ===== Install SonarQube =====
   exec { 'untar':
-    command => "unzip -o ${tmpzip} -d ${installroot} && chown -R ${user}:${group} ${installroot}/${package_name}-${version} && chown -R ${user}:${group} ${real_home}",
+    command => "unzip -o ${tmpzip} -d ${installroot} && chown -R \
+      ${user}:${group} ${installroot}/${package_name}-${version} && chown -R ${user}:${group} ${real_home}",
     creates => "${installroot}/${package_name}-${version}/bin",
     notify  => Service['sonarqube'],
   }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,8 @@ class sonarqube (
   $service          = 'sonar',
   $installroot      = '/usr/local',
   $home             = undef,
+  $data_dir         = undef,
+  $temp_dir         = undef,
   $host             = undef,
   $port             = 9000,
   $portAjp          = -1,
@@ -42,7 +44,7 @@ class sonarqube (
     min_evictable_idle_time_millis    => '600000',
     time_between_eviction_runs_millis => '30000',
   },
-  $log_folder       = '/var/local/sonar/logs',
+  $log_folder       = undef,
   $updatecenter     = true,
   $http_proxy       = {},
   $profile          = false,
@@ -71,6 +73,19 @@ class sonarqube (
   } else {
     $real_home = '/var/local/sonar'
   }
+
+  if $data_dir != undef {
+    $real_data_dir = $data_dir
+  } else {
+    $real_data_dir = "${real_home}/data"
+  }
+
+  if $log_folder != undef {
+    $real_log_folder = $log_folder
+  } else {
+    $real_log_folder = '/var/local/sonar/logs'
+  }
+
   Sonarqube::Move_to_home {
     home => $real_home,
   }
@@ -125,8 +140,48 @@ class sonarqube (
     target => "${installroot}/${package_name}-${version}",
     notify => Service['sonarqube'],
   }
-  ->
-  sonarqube::move_to_home { 'data': }
+  if $data_dir != undef {
+    exec { 'create_data_dir':
+      command => "mkdir -p ${real_data_dir}",
+      creates => $real_data_dir,
+      require => File[$real_home],
+    }
+    ->
+    file { $real_data_dir:
+      ensure => directory,
+      owner  => $user,
+      group  => $group,
+    }
+  }
+  if $temp_dir != undef {
+    exec { 'create_temp_dir':
+      command => "mkdir -p ${temp_dir}",
+      creates => $temp_dir,
+      require => File[$real_home],
+    }
+    ->
+    file { $temp_dir:
+      ensure => directory,
+      owner  => $user,
+      group  => $group,
+    }
+  }
+  if $log_folder != undef {
+    exec { 'create_log_folder':
+      command => "mkdir -p ${real_log_folder}",
+      creates => $real_log_folder,
+      require => File[$real_home],
+    }
+    ->
+    file { $real_log_folder:
+      ensure => directory,
+      owner  => $user,
+      group  => $group,
+    }
+  }
+  sonarqube::move_to_home { 'data':
+    require => File[$real_home],
+  }
   ->
   sonarqube::move_to_home { 'extras': }
   ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -46,6 +46,7 @@ class sonarqube (
   },
   $log_folder       = undef,
   $updatecenter     = true,
+  $updatecenter_url = 'http://update.sonarsource.org/update-center.properties',
   $http_proxy       = {},
   $profile          = false,
   $web_java_opts    = undef,

--- a/templates/logback.xml.erb
+++ b/templates/logback.xml.erb
@@ -22,9 +22,9 @@
   <!-- SONAR_STANDALONE/ -->
   <!-- do not edit/remove the previous comment -->
   <appender name="SONAR_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <File><%= @log_folder %>/sonar.log</File>
+    <File><%= @real_log_folder %>/sonar.log</File>
     <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-      <param name="FileNamePattern" value="<%= @log_folder %>/sonar.%i.log"/>
+      <param name="FileNamePattern" value="<%= @real_log_folder %>/sonar.%i.log"/>
       <param name="MinIndex" value="1"/>
       <param name="MaxIndex" value="3"/>
     </rollingPolicy>
@@ -48,9 +48,9 @@
   <!-- appender used to profile Sonar Server -->
   <%= "<!--" if !@profile %>
   <appender name="PROFILING_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <File><%= @log_folder %>/profiling.log</File>
+    <File><%= @real_log_folder %>/profiling.log</File>
     <rollingPolicy class="ch.qos.logback.core.rolling.FixedWindowRollingPolicy">
-      <param name="FileNamePattern" value="<%= @log_folder %>/profiling.%i.log"/>
+      <param name="FileNamePattern" value="<%= @real_log_folder %>/profiling.%i.log"/>
       <param name="MinIndex" value="1"/>
       <param name="MaxIndex" value="3"/>
     </rollingPolicy>

--- a/templates/sonar.properties.erb
+++ b/templates/sonar.properties.erb
@@ -212,13 +212,16 @@ sonar.jdbc.timeBetweenEvictionRunsMillis:  <% if @jdbc['time_between_eviction_ru
 # Can be absolute or relative to installation directory.
 # Defaults are respectively <installation home>/data and <installation home>/temp
 
-<% if !@path.empty? -%>
-sonar.path.data: <% if @path['data'] %><%= @path['data'] %><% else %>data<% end %>
-sonar.path.temp: <% if @path['temp'] %><%= @path['data'] %><% else %>temp<% end %>
+<% if !@data_dir.nil? -%>
+sonar.path.data: <%= @data_dir %>
 <% else -%>
-#sonar.path.data=data
-#sonar.path.temp=temp
+#sonar.path.data: data
 <% end -%>
+<% if !@temp_dir.nil? -%>
+sonar.path.temp: <%= @temp_dir %>
+<% else -%>
+#sonar.path.temp: temp
+<% end %>
 
 #---------------------------------------------------------
 # UPDATE CENTER

--- a/templates/sonar.properties.erb
+++ b/templates/sonar.properties.erb
@@ -212,15 +212,9 @@ sonar.jdbc.timeBetweenEvictionRunsMillis:  <% if @jdbc['time_between_eviction_ru
 # Can be absolute or relative to installation directory.
 # Defaults are respectively <installation home>/data and <installation home>/temp
 
-<% if !@data_dir.nil? -%>
-sonar.path.data: <%= @data_dir %>
-<% else -%>
-#sonar.path.data: data
-<% end -%>
-<% if !@temp_dir.nil? -%>
-sonar.path.temp: <%= @temp_dir %>
-<% else -%>
-#sonar.path.temp: temp
+<% if !@path.empty? -%>
+<% if @path['data_dir'] %><%= "sonar.path.data: #{@path['data_dir']}" %><% end %>
+<% if @path['temp_dir'] %><%= "sonar.path.temp: #{@path['temp_dir']}" %><% end %>
 <% end %>
 
 #---------------------------------------------------------

--- a/templates/sonar.properties.erb
+++ b/templates/sonar.properties.erb
@@ -205,6 +205,22 @@ sonar.jdbc.timeBetweenEvictionRunsMillis:  <% if @jdbc['time_between_eviction_ru
 <% end -%>
 
 #---------------------------------------------------------
+# DATA FILES PROPERTIES
+#---------------------------------------------------------
+
+# Paths to persistent data files (embedded database and search index) and temporary files.
+# Can be absolute or relative to installation directory.
+# Defaults are respectively <installation home>/data and <installation home>/temp
+
+<% if !@path.empty? -%>
+sonar.path.data: <% if @path['data'] %><%= @path['data'] %><% else %>data<% end %>
+sonar.path.temp: <% if @path['temp'] %><%= @path['data'] %><% else %>temp<% end %>
+<% else -%>
+#sonar.path.data=data
+#sonar.path.temp=temp
+<% end -%>
+
+#---------------------------------------------------------
 # UPDATE CENTER
 #---------------------------------------------------------
 

--- a/templates/sonar.properties.erb
+++ b/templates/sonar.properties.erb
@@ -224,6 +224,7 @@ sonar.jdbc.timeBetweenEvictionRunsMillis:  <% if @jdbc['time_between_eviction_ru
 # The Update Center requires an internet connection to request http://update.sonarsource.org
 # It is activated by default:
 sonar.updatecenter.activate=<%= @updatecenter %>
+sonar.updatecenter.url=<%= @updatecenter_url %>
 
 <% if !@http_proxy.empty? -%>
 # HTTP proxy (default none)

--- a/templates/sonar.properties.erb
+++ b/templates/sonar.properties.erb
@@ -16,7 +16,7 @@ sonar.web.host:                           <%= @host %>
 #sonar.web.host:                           0.0.0.0
 <% end -%>
 sonar.web.port:                           <%= @port %>
-sonar.ajp.port:                           <%= @portAjp %>
+sonar.ajp.port:                           <%= @portajp %>
 <% if has_variable?('context_path') -%>
 sonar.web.context:                        <%= @context_path %>
 <% end -%>


### PR DESCRIPTION
This change allows you to specify custom "data_dir" and "temp_dir" parameters in Sonarqube configuration (sonar.properties file) and allows puppet-module to create these directories during the setup.
Reference: http://stackoverflow.com/questions/31116309/how-to-change-data-folder-in-sonarqube

Also, it allows specifying custom log directory. Previously, log directory was hardcoded to "/var/local/sonar/logs", which is still declared as a default one
