### PR TITLE
Allow installation from OS packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,38 +6,16 @@ before_install:
   - rm -f Gemfile.lock
 
 rvm:
-  - "2.0.0"
+  - "2.1.9"
+  - "2.2.5"
+  - "2.3.3"
 
 env:
-  - PUPPET_VERSION="~> 3.7.0"
-  - PUPPET_VERSION="~> 3.6.0"
-  - PUPPET_VERSION="~> 3.5.0"
-  - PUPPET_VERSION="~> 3.4.0"
-  - PUPPET_VERSION="~> 3.3.0"
-  - PUPPET_VERSION="~> 3.2.0"
-
-matrix:
-  exclude:
-    # No support for Ruby 2.0 before Puppet 3.2
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 2.7.0"
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 3.0.0"
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 3.1.0"
-    # Puppet < 3.5.0 is broken under ruby 2.1 https://tickets.puppetlabs.com/browse/PUP-1243
-    - rvm: 2.1.0
-      env: PUPPET_VERSION="~> 2.7.0"
-    - rvm: 2.1.0
-      env: PUPPET_VERSION="~> 3.0.0"
-    - rvm: 2.1.0
-      env: PUPPET_VERSION="~> 3.1.0"
-    - rvm: 2.1.0
-      env: PUPPET_VERSION="~> 3.2.0"
-    - rvm: 2.1.0
-      env: PUPPET_VERSION="~> 3.3.0"
-    - rvm: 2.1.0
-      env: PUPPET_VERSION="~> 3.4.0"
+  - PUPPET_VERSION="~> 4.9.4"
+  - PUPPET_VERSION="~> 4.8.2"
+  - PUPPET_VERSION="~> 4.7.1"
+  - PUPPET_VERSION="~> 4.6.2"
+  - PUPPET_VERSION="~> 3.8.7"
 
 deploy:
   provider: puppetforge
@@ -49,4 +27,4 @@ deploy:
     # all_branches is required to use tags
     all_branches: true
     # Only publish if our main Ruby target builds
-    condition: "$PUPPET_VERSION = '~> 3.6.0'"
+    condition: "$PUPPET_VERSION = '~> 3.8.7'"

--- a/Gemfile
+++ b/Gemfile
@@ -1,17 +1,33 @@
 # This file is managed centrally by modulesync
 #   https://github.com/maestrodev/puppet-modulesync
 
-source 'https://rubygems.org'
+source ENV['GEM_SOURCE'] || "https://rubygems.org"
 
-gem 'puppet', ENV['PUPPET_VERSION'] || '>= 2.7', :require => false
+ENV['PUPPET_VERSION'].nil? ? puppetversion = '~>3.8.7' : puppetversion = ENV['PUPPET_VERSION'].to_s
+gem 'puppet', puppetversion, :require => false, :groups => [:test]
+gem 'safe_yaml', '~> 1.0.4'
 
-gem 'rake', :require => false
-gem 'rspec-puppet', '>= 1.0.0', :require => false
-gem 'puppetlabs_spec_helper', '>= 0.8.0', :require => false
-gem 'puppet-lint', '>= 1.1.0', :require => false
-gem 'simplecov', :require => false
-gem 'puppet-blacksmith', '>= 3.3.1', :require => false
-gem 'librarian-puppet', '>= 2.0.0', :require => false
-gem 'beaker-rspec', '>= 3.0.0', :require => false
+group :test do
+  gem 'puppetlabs_spec_helper', '~> 2.0.1',                         :require => false
+  gem 'parallel_tests',                                             :require => false
+  gem 'rspec-puppet', '~> 2.5',                                     :require => false
+  gem 'rspec-puppet-facts',                                         :require => false
+  gem 'rspec-puppet-utils',                                         :require => false
+  gem 'puppet-lint-absolute_classname-check',                       :require => false
+  gem 'puppet-lint-leading_zero-check',                             :require => false
+  gem 'puppet-lint-trailing_comma-check',                           :require => false
+  gem 'puppet-lint-version_comparison-check',                       :require => false
+  gem 'puppet-lint-classes_and_types_beginning_with_digits-check',  :require => false
+  gem 'puppet-lint-unquoted_string-check',                          :require => false
+  gem 'puppet-lint-variable_contains_upcase',                       :require => false
+  gem 'metadata-json-lint',                                         :require => false
+  gem 'simplecov-console',                                          :require => false
+  gem 'coveralls',                                                  :require => false
+  gem 'rake',                                                       :require => false
+  gem 'puppet-blacksmith',                                          :require => false
+  gem 'librarian-puppet',                                           :require => false
+  gem 'beaker-rspec',                                               :require => false
+end
+
 
 # vim:ft=ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,71 +1,94 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.0)
-    activemodel (4.2.0)
-      activesupport (= 4.2.0)
-      builder (~> 3.1)
-    activesupport (4.2.0)
-      i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
-      tzinfo (~> 1.1)
-    addressable (2.3.7)
-    archive-tar-minitar (0.5.2)
-    autoparse (0.3.3)
-      addressable (>= 2.3.1)
-      extlib (>= 0.9.15)
-      multi_json (>= 1.0.0)
-    aws-sdk (1.63.0)
-      aws-sdk-v1 (= 1.63.0)
-    aws-sdk-v1 (1.63.0)
+    CFPropertyList (2.3.5)
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
+    ansi (1.5.0)
+    aws-sdk-v1 (1.66.0)
       json (~> 1.4)
       nokogiri (>= 1.4.4)
-    beaker (2.4.1)
-      aws-sdk (~> 1.57)
+    beaker (3.13.0)
+      aws-sdk-v1 (~> 1.57)
+      beaker-hiera (~> 0.0)
+      beaker-hostgenerator
       docker-api
       fission (~> 0.4)
-      fog (~> 1.25)
-      google-api-client (~> 0.7)
-      hocon (~> 0.0.4)
-      inifile (~> 2.0)
-      json (~> 1.8)
+      fog (~> 1.38)
+      google-api-client (~> 0.9)
+      hocon (~> 1.0)
+      in-parallel (~> 0.1)
+      inifile (~> 3.0)
+      minitar (~> 0.5.4)
       minitest (~> 5.4)
       net-scp (~> 1.2)
-      net-ssh (~> 2.9)
-      rbvmomi (~> 1.8)
+      net-ssh (~> 4.0)
+      open_uri_redirections (~> 0.2.1)
+      rake (~> 10.0)
+      rbvmomi (~> 1.9)
+      rsync (~> 1.0.9)
+      stringify-hash (~> 0.0)
+      thor (= 0.19.1)
       unf (~> 0.1)
-    beaker-rspec (4.0.0)
-      beaker (~> 2.0)
-      rspec
-      serverspec (~> 1.0)
-      specinfra (~> 1.0)
-    builder (3.2.2)
-    diff-lcs (1.2.5)
+    beaker-hiera (0.1.1)
+      stringify-hash (~> 0.0.0)
+    beaker-hostgenerator (0.8.3)
+      deep_merge (~> 1.0)
+      stringify-hash (~> 0.0.0)
+    beaker-rspec (6.1.0)
+      beaker (~> 3.0)
+      rspec (~> 3.0)
+      serverspec (~> 2)
+      specinfra (~> 2)
+    builder (3.2.3)
+    coveralls (0.8.19)
+      json (>= 1.8, < 3)
+      simplecov (~> 0.12.0)
+      term-ansicolor (~> 1.3)
+      thor (~> 0.19.1)
+      tins (~> 1.6)
+    declarative (0.0.9)
+    declarative-option (0.1.0)
+    deep_merge (1.1.1)
+    diff-lcs (1.3)
     docile (1.1.5)
-    docker-api (1.19.0)
-      archive-tar-minitar
+    docker-api (1.33.2)
       excon (>= 0.38.0)
       json
     domain_name (0.5.24)
       unf (>= 0.0.5, < 1.0.0)
-    excon (0.44.2)
-    extlib (0.9.16)
-    facter (1.7.6)
-    faraday (0.9.1)
+    excon (0.55.0)
+    facter (2.4.6)
+    facterdb (0.3.10)
+      facter
+      jgrep
+    faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
+    faraday_middleware (0.10.1)
+      faraday (>= 0.7.4, < 1.0)
+    fast_gettext (1.1.0)
     fission (0.5.0)
       CFPropertyList (~> 2.2)
-    fog (1.27.0)
+    fog (1.40.0)
+      fog-aliyun (>= 0.1.0)
       fog-atmos
-      fog-aws (~> 0.0)
+      fog-aws (>= 0.6.0)
       fog-brightbox (~> 0.4)
-      fog-core (~> 1.27, >= 1.27.3)
-      fog-ecloud
+      fog-cloudatcost (~> 0.1.0)
+      fog-core (~> 1.43)
+      fog-digitalocean (>= 0.3.0)
+      fog-dnsimple (~> 1.0)
+      fog-dynect (~> 0.0.2)
+      fog-ecloud (~> 0.1)
+      fog-google (<= 0.1.0)
       fog-json
+      fog-local
+      fog-openstack
+      fog-powerdns (>= 0.1.1)
       fog-profitbricks
+      fog-rackspace
       fog-radosgw (>= 0.0.2)
+      fog-riakcs
       fog-sakuracloud (>= 0.0.4)
       fog-serverlove
       fog-softlayer
@@ -73,195 +96,349 @@ GEM
       fog-terremark
       fog-vmfusion
       fog-voxel
+      fog-vsphere (>= 0.4.0)
+      fog-xenserver
       fog-xml (~> 0.1.1)
       ipaddress (~> 0.5)
-      nokogiri (~> 1.5, >= 1.5.11)
+      json (>= 1.8, < 2.0)
+    fog-aliyun (0.1.0)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      ipaddress (~> 0.8)
+      xml-simple (~> 1.1)
     fog-atmos (0.1.0)
       fog-core
       fog-xml
-    fog-aws (0.1.0)
-      fog-core (~> 1.27)
+    fog-aws (1.3.0)
+      fog-core (~> 1.38)
       fog-json (~> 1.0)
       fog-xml (~> 0.1)
       ipaddress (~> 0.8)
-    fog-brightbox (0.7.1)
+    fog-brightbox (0.11.0)
       fog-core (~> 1.22)
       fog-json
       inflecto (~> 0.0.2)
-    fog-core (1.28.0)
+    fog-cloudatcost (0.1.2)
+      fog-core (~> 1.36)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (1.43.0)
       builder
-      excon (~> 0.38)
+      excon (~> 0.49)
       formatador (~> 0.2)
-      mime-types
-      net-scp (~> 1.1)
-      net-ssh (>= 2.1.3)
-    fog-ecloud (0.0.2)
+    fog-digitalocean (0.3.0)
+      fog-core (~> 1.42)
+      fog-json (>= 1.0)
+      fog-xml (>= 0.1)
+      ipaddress (>= 0.5)
+    fog-dnsimple (1.0.0)
+      fog-core (~> 1.38)
+      fog-json (~> 1.0)
+    fog-dynect (0.0.3)
+      fog-core
+      fog-json
+      fog-xml
+    fog-ecloud (0.3.0)
       fog-core
       fog-xml
-    fog-json (1.0.0)
-      multi_json (~> 1.0)
-    fog-profitbricks (0.0.1)
+    fog-google (0.1.0)
       fog-core
+      fog-json
       fog-xml
-      nokogiri
-    fog-radosgw (0.0.3)
+    fog-json (1.0.2)
+      fog-core (~> 1.0)
+      multi_json (~> 1.10)
+    fog-local (0.3.1)
+      fog-core (~> 1.27)
+    fog-openstack (0.1.20)
+      fog-core (>= 1.40)
+      fog-json (>= 1.0)
+      ipaddress (>= 0.8)
+    fog-powerdns (0.1.1)
+      fog-core (~> 1.27)
+      fog-json (~> 1.0)
+      fog-xml (~> 0.1)
+    fog-profitbricks (3.0.0)
+      fog-core (~> 1.42)
+      fog-json (~> 1.0)
+    fog-rackspace (0.1.4)
+      fog-core (>= 1.35)
+      fog-json (>= 1.0)
+      fog-xml (>= 0.1)
+      ipaddress (>= 0.8)
+    fog-radosgw (0.0.5)
       fog-core (>= 1.21.0)
       fog-json
       fog-xml (>= 0.0.1)
-    fog-sakuracloud (1.0.0)
+    fog-riakcs (0.1.0)
       fog-core
       fog-json
-    fog-serverlove (0.1.1)
+      fog-xml
+    fog-sakuracloud (1.7.5)
       fog-core
       fog-json
-    fog-softlayer (0.4.1)
+    fog-serverlove (0.1.2)
       fog-core
       fog-json
-    fog-storm_on_demand (0.1.0)
+    fog-softlayer (1.1.4)
       fog-core
       fog-json
-    fog-terremark (0.0.4)
+    fog-storm_on_demand (0.1.1)
+      fog-core
+      fog-json
+    fog-terremark (0.1.0)
       fog-core
       fog-xml
-    fog-vmfusion (0.0.1)
+    fog-vmfusion (0.1.0)
       fission
       fog-core
-    fog-voxel (0.0.2)
+    fog-voxel (0.1.0)
       fog-core
       fog-xml
-    fog-xml (0.1.1)
+    fog-vsphere (1.8.0)
+      fog-core
+      rbvmomi (~> 1.9)
+    fog-xenserver (0.3.0)
+      fog-core
+      fog-xml
+    fog-xml (0.1.2)
       fog-core
       nokogiri (~> 1.5, >= 1.5.11)
     formatador (0.2.5)
-    google-api-client (0.8.2)
-      activesupport (>= 3.2)
+    gettext (3.2.2)
+      locale (>= 2.0.5)
+      text (>= 1.3.0)
+    gettext-setup (0.20)
+      fast_gettext (~> 1.1.0)
+      gettext (>= 3.0.2)
+      locale
+    google-api-client (0.10.2)
       addressable (~> 2.3)
-      autoparse (~> 0.3)
-      extlib (~> 0.9)
+      googleauth (~> 0.5)
+      httpclient (~> 2.7)
+      hurley (~> 0.1)
+      memoist (~> 0.11)
+      mime-types (>= 1.6)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+    googleauth (0.5.1)
       faraday (~> 0.9)
-      launchy (~> 2.4)
-      multi_json (~> 1.10)
-      retriable (~> 1.4)
-      signet (~> 0.6)
-    her (0.7.3)
-      activemodel (>= 3.0.0, <= 4.2)
-      activesupport (>= 3.0.0, <= 4.2)
-      faraday (>= 0.8, < 1.0)
-      multi_json (~> 1.7)
+      jwt (~> 1.4)
+      logging (~> 2.0)
+      memoist (~> 0.12)
+      multi_json (~> 1.11)
+      os (~> 0.9)
+      signet (~> 0.7)
     hiera (1.3.4)
       json_pure
-    highline (1.7.1)
-    hocon (0.0.7)
+    hirb (0.7.3)
+    hocon (1.2.4)
     http-cookie (1.0.2)
       domain_name (~> 0.5)
-    i18n (0.7.0)
+    httpclient (2.8.3)
+    hurley (0.2)
+    in-parallel (0.1.17)
     inflecto (0.0.2)
-    inifile (2.0.2)
-    ipaddress (0.8.0)
-    json (1.8.2)
-    json_pure (1.8.2)
-    jwt (1.2.1)
-    launchy (2.4.3)
-      addressable (~> 2.3)
-    librarian-puppet (2.1.0)
-      librarianp (>= 0.4.0)
-      puppet_forge
+    inifile (3.0.0)
+    ipaddress (0.8.3)
+    jgrep (1.4.1)
+      json
+    json (1.8.6)
+    json_pure (2.0.3)
+    jwt (1.5.6)
+    librarian-puppet (2.2.3)
+      librarianp (>= 0.6.3)
+      puppet_forge (~> 2.1)
       rsync
-    librarianp (0.6.0)
+    librarianp (0.6.3)
       thor (~> 0.15)
+    little-plugger (1.1.4)
+    locale (2.1.2)
+    logging (2.2.0)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
+    mcollective-client (2.10.2)
+      json
+      stomp
+      systemu
+    memoist (0.15.0)
     metaclass (0.0.4)
-    mime-types (2.4.3)
-    mini_portile (0.6.2)
-    minitest (5.5.1)
-    mocha (1.1.0)
+    metadata-json-lint (1.1.0)
+      json
+      semantic_puppet (>= 0.1.2, < 2.0.0)
+      spdx-licenses (~> 1.0)
+    mime-types (2.99.3)
+    mini_portile2 (2.1.0)
+    minitar (0.5.4)
+    minitest (5.10.1)
+    mocha (1.2.1)
       metaclass (~> 0.0.1)
-    multi_json (1.10.1)
+    multi_json (1.12.1)
     multipart-post (2.0.0)
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
-    net-ssh (2.9.2)
+    net-ssh (4.1.0)
+    net-telnet (0.1.1)
     netrc (0.10.3)
-    nokogiri (1.6.6.2)
-      mini_portile (~> 0.6.0)
-    puppet (3.7.4)
+    nokogiri (1.7.1)
+      mini_portile2 (~> 2.1.0)
+    open_uri_redirections (0.2.1)
+    os (0.9.6)
+    parallel (1.11.1)
+    parallel_tests (2.14.0)
+      parallel
+    public_suffix (2.0.5)
+    puppet (3.8.7)
       facter (> 1.6, < 3)
       hiera (~> 1.0)
       json_pure
     puppet-blacksmith (3.3.1)
       puppet (>= 2.7.16)
       rest-client
-    puppet-lint (1.1.0)
-    puppet-syntax (2.0.0)
+    puppet-lint (2.2.1)
+    puppet-lint-absolute_classname-check (0.2.4)
+      puppet-lint (>= 1.0, < 3.0)
+    puppet-lint-classes_and_types_beginning_with_digits-check (0.1.2)
+      puppet-lint (>= 1.0, < 3.0)
+    puppet-lint-leading_zero-check (0.1.1)
+      puppet-lint (>= 1.0, < 3.0)
+    puppet-lint-trailing_comma-check (0.3.2)
+      puppet-lint (>= 1.0, < 3.0)
+    puppet-lint-unquoted_string-check (0.3.0)
+      puppet-lint (>= 1.0, < 3.0)
+    puppet-lint-variable_contains_upcase (1.2.0)
+      puppet-lint (>= 1.0, < 3.0)
+    puppet-lint-version_comparison-check (0.2.1)
+      puppet-lint (>= 1.0, < 3.0)
+    puppet-syntax (2.4.0)
       rake
-    puppet_forge (1.0.4)
-      her (~> 0.6)
-    puppetlabs_spec_helper (0.9.1)
-      mocha
-      puppet-lint
-      puppet-syntax
-      rake
-      rspec-puppet
+    puppet_forge (2.2.3)
+      faraday (~> 0.9.0)
+      faraday_middleware (>= 0.9.0, < 0.11.0)
+      gettext-setup (~> 0.11)
+      minitar
+      semantic_puppet (~> 0.1.0)
+    puppetlabs_spec_helper (2.0.2)
+      mocha (~> 1.0)
+      puppet-lint (~> 2.0)
+      puppet-syntax (~> 2.0)
+      rspec-puppet (~> 2.0)
     rake (10.4.2)
-    rbvmomi (1.8.2)
-      builder
-      nokogiri (>= 1.4.1)
-      trollop
+    rbvmomi (1.10.0)
+      builder (~> 3.0)
+      json (>= 1.8)
+      nokogiri (~> 1.5)
+      trollop (~> 2.1)
+    representable (3.0.3)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
     rest-client (1.8.0)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
-    retriable (1.4.1)
-    rspec (2.99.0)
-      rspec-core (~> 2.99.0)
-      rspec-expectations (~> 2.99.0)
-      rspec-mocks (~> 2.99.0)
-    rspec-core (2.99.2)
-    rspec-expectations (2.99.2)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-its (1.0.1)
-      rspec-core (>= 2.99.0.beta1)
-      rspec-expectations (>= 2.99.0.beta1)
-    rspec-mocks (2.99.3)
-    rspec-puppet (2.0.0)
-      rspec (~> 2.0)
+    retriable (3.0.1)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.4)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-its (1.2.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
+    rspec-mocks (3.5.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.5.0)
+    rspec-puppet (2.5.0)
+      rspec
+    rspec-puppet-facts (1.7.1)
+      facter
+      facterdb (>= 0.3.0)
+      json
+      mcollective-client
+      puppet
+    rspec-puppet-utils (3.1.0)
+      mocha
+      puppet (>= 3)
+      puppetlabs_spec_helper
+      rspec
+      rspec-puppet
+    rspec-support (3.5.0)
     rsync (1.0.9)
-    serverspec (1.16.0)
-      highline
-      net-ssh
-      rspec (~> 2.99)
+    safe_yaml (1.0.4)
+    semantic_puppet (0.1.4)
+      gettext-setup (>= 0.3)
+    serverspec (2.38.0)
+      multi_json
+      rspec (~> 3.0)
       rspec-its
-      specinfra (~> 1.27)
-    signet (0.6.0)
+      specinfra (~> 2.53)
+    sfl (2.3)
+    signet (0.7.3)
       addressable (~> 2.3)
-      extlib (~> 0.9)
       faraday (~> 0.9)
-      jwt (~> 1.0)
+      jwt (~> 1.5)
       multi_json (~> 1.10)
-    simplecov (0.9.2)
+    simplecov (0.12.0)
       docile (~> 1.1.0)
-      multi_json (~> 1.0)
-      simplecov-html (~> 0.9.0)
-    simplecov-html (0.9.0)
-    specinfra (1.27.5)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-console (0.4.1)
+      ansi
+      hirb
+      simplecov
+    simplecov-html (0.10.0)
+    spdx-licenses (1.1.0)
+    specinfra (2.67.7)
+      net-scp
+      net-ssh (>= 2.7, < 5.0)
+      net-telnet
+      sfl
+    stomp (1.4.3)
+    stringify-hash (0.0.2)
+    systemu (2.6.5)
+    term-ansicolor (1.5.0)
+      tins (~> 1.0)
+    text (1.3.1)
     thor (0.19.1)
-    thread_safe (0.3.4)
-    trollop (2.1.1)
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
+    tins (1.13.2)
+    trollop (2.1.2)
+    uber (0.1.0)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.6)
+    unf_ext (0.0.7.2)
+    xml-simple (1.1.5)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  beaker-rspec (>= 3.0.0)
-  librarian-puppet (>= 2.0.0)
-  puppet (>= 2.7)
-  puppet-blacksmith (>= 3.3.1)
-  puppet-lint (>= 1.1.0)
-  puppetlabs_spec_helper (>= 0.8.0)
+  beaker-rspec
+  coveralls
+  librarian-puppet
+  metadata-json-lint
+  parallel_tests
+  puppet (~> 3.8.7)
+  puppet-blacksmith
+  puppet-lint-absolute_classname-check
+  puppet-lint-classes_and_types_beginning_with_digits-check
+  puppet-lint-leading_zero-check
+  puppet-lint-trailing_comma-check
+  puppet-lint-unquoted_string-check
+  puppet-lint-variable_contains_upcase
+  puppet-lint-version_comparison-check
+  puppetlabs_spec_helper (~> 2.0.1)
   rake
-  rspec-puppet (>= 1.0.0)
-  simplecov
+  rspec-puppet (~> 2.5)
+  rspec-puppet-facts
+  rspec-puppet-utils
+  safe_yaml (~> 1.0.4)
+  simplecov-console
+
+BUNDLED WITH
+   1.14.6

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,5 +1,5 @@
 forge 'https://forgeapi.puppetlabs.com'
 
-mod 'puppetlabs/stdlib', '>=2.3.0'
+mod 'puppetlabs/stdlib', '>=4.6.0'
 mod 'maestrodev/wget',   '>=0.0.1'
 mod 'maestrodev/maven',  '>=1.0.0'

--- a/Puppetfile.lock
+++ b/Puppetfile.lock
@@ -1,13 +1,13 @@
 FORGE
-  remote: http://forge.puppetlabs.com
+  remote: https://forgeapi.puppetlabs.com
   specs:
-    maestrodev/maven (1.1.9)
-      maestrodev/wget (>= 1.0.0)
-    maestrodev/wget (1.3.1)
-    puppetlabs/stdlib (4.1.0)
+    maestrodev-maven (1.1.9)
+      maestrodev-wget (>= 1.0.0)
+    maestrodev-wget (1.3.1)
+    puppetlabs-stdlib (4.16.0)
 
 DEPENDENCIES
-  maestrodev/maven (>= 1.0.0)
-  maestrodev/wget (>= 0.0.1)
-  puppetlabs/stdlib (>= 2.3.0)
+  maestrodev-maven (>= 1.0.0)
+  maestrodev-wget (>= 0.0.1)
+  puppetlabs-stdlib (>= 4.6.0)
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,0 +1,38 @@
+# sonarqube configuration
+class sonarqube::config {
+
+  # this class intended to be used from main sonarqube class
+  assert_private()
+
+  $config           = $::sonarqube::config
+  $context_path     = $::sonarqube::context_path
+  $crowd            = $::sonarqube::crowd
+  $host             = $::sonarqube::host
+  $http_proxy       = $::sonarqube::http_proxy
+  $https            = $::sonarqube::https
+  $installdir       = $::sonarqube::installdir
+  $jdbc             = $::sonarqube::jdbc
+  $ldap             = $::sonarqube::ldap
+  $pam              = $::sonarqube::pam
+  $port_ajp         = $::sonarqube::port_ajp
+  $port             = $::sonarqube::port
+  $search_host      = $::sonarqube::search_host
+  $search_java_opts = $::sonarqube::search_java_opts
+  $search_port      = $::sonarqube::search_port
+  $updatecenter     = $::sonarqube::updatecenter
+  $web_java_opts    = $::sonarqube::web_java_opts
+
+  # Sonar configuration files
+  if $config != undef {
+    file { "${installdir}/conf/sonar.properties":
+      source => $config,
+      mode   => '0600',
+    }
+  } else {
+    file { "${installdir}/conf/sonar.properties":
+      content => template('sonarqube/sonar.properties.erb'),
+      mode    => '0600',
+    }
+  }
+
+}

--- a/manifests/firewall.pp
+++ b/manifests/firewall.pp
@@ -1,0 +1,23 @@
+# manage firewall for sonarqube service
+class sonarqube::firewall {
+
+  # this class intended to be used from main sonarqube class
+  assert_private()
+
+  $manage_firewall = $sonarqube::manage_firewall
+  $port            = $sonarqube::port
+
+  if $manage_firewall {
+    firewall { '00100 input accept http for sonarqube':
+        ensure => 'present',
+        action => 'accept',
+        chain  => 'INPUT',
+        dport  => [$port],
+        proto  => 'tcp',
+        state  => ['NEW'],
+        table  => 'filter',
+    }
+
+  }
+
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,15 +68,15 @@ class sonarqube (
     $real_home = '/var/local/sonar'
   }
 
-  anchor { 'sonarqube::begin': } ->
-  class { '::sonarqube::user': } ->
-  class { '::sonarqube::install': } ->
-  class { '::sonarqube::config': } ~>
-  class { '::sonarqube::service': } ->
-  class { '::sonarqube::firewall': } ->
-  anchor { 'sonarqube::end': }
+  anchor { 'sonarqube::begin': }
+  -> class { '::sonarqube::user': }
+  -> class { '::sonarqube::install': }
+  -> class { '::sonarqube::config': }
+  ~> class { '::sonarqube::service': }
+  -> class { '::sonarqube::firewall': }
+  -> anchor { 'sonarqube::end': }
 
-  Class['::sonarqube::install'] ~>
-  Class['::sonarqube::service']
+  Class['::sonarqube::install']
+  ~> Class['::sonarqube::service']
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,7 +21,7 @@ class sonarqube (
   $home             = undef,
   $host             = undef,
   $port             = 9000,
-  $portAjp          = -1,
+  $port_ajp         = -1,
   $download_url     = 'https://sonarsource.bintray.com/Distribution/sonarqube',
   $download_dir     = '/usr/local/src',
   $context_path     = '/',
@@ -51,151 +51,32 @@ class sonarqube (
   $search_host      = '127.0.0.1',
   $search_port      = '9001',
   $config           = undef,
+  $use_packages     = false,
+  $package_name     = 'sonarqube',
+  $manage_user      = true,
+  $manage_firewall  = false,
+
 ) inherits sonarqube::params {
-  validate_absolute_path($download_dir)
-  Exec {
-    path => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
-  }
-  File {
-    owner => $user,
-    group => $group,
-  }
 
-  # wget from https://github.com/maestrodev/puppet-wget
-  include wget
+  validate_absolute_path($installroot)
+  validate_bool($use_packages)
 
-  $package_name = 'sonarqube'
-
+  $installdir = "${installroot}/${service}"
   if $home != undef {
     $real_home = $home
   } else {
     $real_home = '/var/local/sonar'
   }
-  Sonarqube::Move_to_home {
-    home => $real_home,
-  }
 
-  $extensions_dir = "${real_home}/extensions"
-  $plugin_dir = "${extensions_dir}/plugins"
+  anchor { 'sonarqube::begin': } ->
+  class { '::sonarqube::user': } ->
+  class { '::sonarqube::install': } ->
+  class { '::sonarqube::config': } ~>
+  class { '::sonarqube::service': } ->
+  class { '::sonarqube::firewall': } ->
+  anchor { 'sonarqube::end': }
 
-  $installdir = "${installroot}/${service}"
-  $tmpzip = "${download_dir}/${package_name}-${version}.zip"
-  $script = "${installdir}/bin/${arch}/sonar.sh"
+  Class['::sonarqube::install'] ~>
+  Class['::sonarqube::service']
 
-  if ! defined(Package[unzip]) {
-    package { 'unzip':
-      ensure => present,
-      before => Exec[untar],
-    }
-  }
-
-  user { $user:
-    ensure     => present,
-    home       => $real_home,
-    managehome => false,
-    system     => $user_system,
-  }
-  ->
-  group { $group:
-    ensure => present,
-    system => $user_system,
-  }
-  ->
-  wget::fetch { 'download-sonar':
-    source      => "${download_url}/${package_name}-${version}.zip",
-    destination => $tmpzip,
-  }
-  ->
-  # ===== Create folder structure =====
-  # so uncompressing new sonar versions at update time use the previous sonar home,
-  # installing new extensions and plugins over the old ones, reusing the db,...
-
-  # Sonar home
-  file { $real_home:
-    ensure => directory,
-    mode   => '0700',
-  }
-  ->
-  file { "${installroot}/${package_name}-${version}":
-    ensure => directory,
-  }
-  ->
-  file { $installdir:
-    ensure => link,
-    target => "${installroot}/${package_name}-${version}",
-    notify => Service['sonarqube'],
-  }
-  ->
-  sonarqube::move_to_home { 'data': }
-  ->
-  sonarqube::move_to_home { 'extras': }
-  ->
-  sonarqube::move_to_home { 'extensions': }
-  ->
-  sonarqube::move_to_home { 'logs': }
-  ->
-  # ===== Install SonarQube =====
-  exec { 'untar':
-    command => "unzip -o ${tmpzip} -d ${installroot} && chown -R ${user}:${group} ${installroot}/${package_name}-${version} && chown -R ${user}:${group} ${real_home}",
-    creates => "${installroot}/${package_name}-${version}/bin",
-    notify  => Service['sonarqube'],
-  }
-  ->
-  file { $script:
-    mode    => '0755',
-    content => template('sonarqube/sonar.sh.erb'),
-  }
-  ->
-  file { "/etc/init.d/${service}":
-    ensure => link,
-    target => $script,
-  }
-
-  # Sonar configuration files
-  if $config != undef {
-    file { "${installdir}/conf/sonar.properties":
-      source  => $config,
-      require => Exec['untar'],
-      notify  => Service['sonarqube'],
-      mode    => '0600',
-    }
-  } else {
-    file { "${installdir}/conf/sonar.properties":
-      content => template('sonarqube/sonar.properties.erb'),
-      require => Exec['untar'],
-      notify  => Service['sonarqube'],
-      mode    => '0600',
-    }
-  }
-
-  file { '/tmp/cleanup-old-plugin-versions.sh':
-    content => template("${module_name}/cleanup-old-plugin-versions.sh.erb"),
-    mode    => '0755',
-  }
-  ->
-  file { '/tmp/cleanup-old-sonarqube-versions.sh':
-    content => template("${module_name}/cleanup-old-sonarqube-versions.sh.erb"),
-    mode    => '0755',
-  }
-  ->
-  exec { 'remove-old-versions-of-sonarqube':
-    command     => "/tmp/cleanup-old-sonarqube-versions.sh ${installroot} ${version}",
-    path        => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
-    refreshonly => true,
-    subscribe   => File["${installroot}/${package_name}-${version}"],
-  }
-
-  # The plugins directory. Useful to later reference it from the plugin definition
-  file { $plugin_dir:
-    ensure => directory,
-  }
-
-  service { 'sonarqube':
-    ensure     => running,
-    name       => $service,
-    hasrestart => true,
-    hasstatus  => true,
-    enable     => true,
-    require    => File["/etc/init.d/${service}"],
-  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -68,6 +68,9 @@ class sonarqube (
     $real_home = '/var/local/sonar'
   }
 
+  $extensions_dir = "${real_home}/extensions"
+  $plugin_dir = "${extensions_dir}/plugins"
+
   anchor { 'sonarqube::begin': }
   -> class { '::sonarqube::user': }
   -> class { '::sonarqube::install': }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,0 +1,14 @@
+# install sonarqube
+class sonarqube::install {
+
+  # this class intended to be used from main sonarqube class
+  assert_private()
+
+  if $::sonarqube::use_packages {
+    contain sonarqube::install::package
+  }
+  else {
+    contain sonarqube::install::source
+  }
+
+}

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,10 +5,10 @@ class sonarqube::install {
   assert_private()
 
   if $::sonarqube::use_packages {
-    contain sonarqube::install::package
+    contain ::sonarqube::install::package
   }
   else {
-    contain sonarqube::install::source
+    contain ::sonarqube::install::source
   }
 
 }

--- a/manifests/install/package.pp
+++ b/manifests/install/package.pp
@@ -1,0 +1,34 @@
+# install sonarqube from packages
+class sonarqube::install::package {
+
+  # this class intended to be used from sonarqube::install class
+  assert_private()
+
+  $arch         = $::sonarqube::arch
+  $installdir   = $::sonarqube::installdir
+  $package_name = $::sonarqube::package_name
+  $version      = $::sonarqube::version
+
+  $arch_dir = "${installdir}/bin/${arch}"
+  $sonar_script = "${arch_dir}/sonar.sh"
+  $pid_file = "${arch_dir}/SonarQube.pid"
+
+  package { $package_name:
+    ensure => $version,
+  }
+  if $facts['service_provider'] == 'systemd' {
+    Package[$package_name] ->
+    file{ '/usr/lib/systemd/system/sonar.service':
+      ensure  => present,
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => template("${module_name}/sonar.service.erb"),
+    }~>
+    exec { 'sonar systemd daemon-reload':
+      command     => '/bin/systemctl daemon-reload',
+      refreshonly => true,
+    }
+  }
+
+}

--- a/manifests/install/package.pp
+++ b/manifests/install/package.pp
@@ -17,15 +17,15 @@ class sonarqube::install::package {
     ensure => $version,
   }
   if $facts['service_provider'] == 'systemd' {
-    Package[$package_name] ->
-    file{ '/usr/lib/systemd/system/sonar.service':
+    Package[$package_name]
+    -> file{ '/usr/lib/systemd/system/sonar.service':
       ensure  => present,
       owner   => 'root',
       group   => 'root',
       mode    => '0644',
       content => template("${module_name}/sonar.service.erb"),
-    }~>
-    exec { 'sonar systemd daemon-reload':
+    }
+    ~> exec { 'sonar systemd daemon-reload':
       command     => '/bin/systemctl daemon-reload',
       refreshonly => true,
     }

--- a/manifests/install/source.pp
+++ b/manifests/install/source.pp
@@ -4,19 +4,21 @@ class sonarqube::install::source {
   # this class intended to be used from sonarqube::install class
   assert_private()
 
-  $arch         = $::sonarqube::arch
-  $config       = $::sonarqube::config
-  $download_dir = $::sonarqube::download_dir
-  $download_url = $::sonarqube::download_url
-  $group        = $::sonarqube::group
-  $installdir   = $::sonarqube::installdir
-  $installroot  = $::sonarqube::installroot
-  $package_name = $::sonarqube::package_name
-  $real_home    = $::sonarqube::real_home
-  $service      = $::sonarqube::service
-  $user         = $::sonarqube::user
-  $user_system  = $::sonarqube::user_system
-  $version      = $::sonarqube::version
+  $arch           = $::sonarqube::arch
+  $config         = $::sonarqube::config
+  $download_dir   = $::sonarqube::download_dir
+  $download_url   = $::sonarqube::download_url
+  $extensions_dir = $::sonarqube::extensions_dir
+  $group          = $::sonarqube::group
+  $installdir     = $::sonarqube::installdir
+  $installroot    = $::sonarqube::installroot
+  $package_name   = $::sonarqube::package_name
+  $plugin_dir     = $::sonarqube::plugin_dir
+  $real_home      = $::sonarqube::real_home
+  $service        = $::sonarqube::service
+  $user           = $::sonarqube::user
+  $user_system    = $::sonarqube::user_system
+  $version        = $::sonarqube::version
 
   validate_absolute_path($download_dir)
   Exec {
@@ -33,9 +35,6 @@ class sonarqube::install::source {
   Sonarqube::Move_to_home {
     home => $real_home,
   }
-
-  $extensions_dir = "${real_home}/extensions"
-  $plugin_dir = "${extensions_dir}/plugins"
 
   $tmpzip = "${download_dir}/${package_name}-${version}.zip"
   $script = "${installdir}/bin/${arch}/sonar.sh"

--- a/manifests/install/source.pp
+++ b/manifests/install/source.pp
@@ -1,0 +1,110 @@
+# install sonarqube from source
+class sonarqube::install::source {
+
+  # this class intended to be used from sonarqube::install class
+  assert_private()
+
+  $arch         = $::sonarqube::arch
+  $config       = $::sonarqube::config
+  $download_dir = $::sonarqube::download_dir
+  $download_url = $::sonarqube::download_url
+  $group        = $::sonarqube::group
+  $installdir   = $::sonarqube::installdir
+  $installroot  = $::sonarqube::installroot
+  $package_name = $::sonarqube::package_name
+  $real_home    = $::sonarqube::real_home
+  $service      = $::sonarqube::service
+  $user         = $::sonarqube::user
+  $user_system  = $::sonarqube::user_system
+  $version      = $::sonarqube::version
+
+  validate_absolute_path($download_dir)
+  Exec {
+    path => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
+  }
+  File {
+    owner => $user,
+    group => $group,
+  }
+
+  # wget from https://github.com/maestrodev/puppet-wget
+  include wget
+
+  Sonarqube::Move_to_home {
+    home => $real_home,
+  }
+
+  $extensions_dir = "${real_home}/extensions"
+  $plugin_dir = "${extensions_dir}/plugins"
+
+  $tmpzip = "${download_dir}/${package_name}-${version}.zip"
+  $script = "${installdir}/bin/${arch}/sonar.sh"
+
+  if ! defined(Package[unzip]) {
+    package { 'unzip':
+      ensure => present,
+      before => Exec[untar],
+    }
+  }
+
+  wget::fetch { 'download-sonar':
+    source      => "${download_url}/${package_name}-${version}.zip",
+    destination => $tmpzip,
+  }
+  # ===== Create folder structure =====
+  # so uncompressing new sonar versions at update time use the previous sonar home,
+  # installing new extensions and plugins over the old ones, reusing the db,...
+
+  # Sonar home
+  -> file { $real_home:
+    ensure => directory,
+    mode   => '0700',
+  }
+  -> file { "${installroot}/${package_name}-${version}":
+    ensure => directory,
+  }
+  -> file { $installdir:
+    ensure => link,
+    target => "${installroot}/${package_name}-${version}",
+    notify => Service['sonarqube'],
+  }
+  -> sonarqube::move_to_home { 'data': }
+  -> sonarqube::move_to_home { 'extras': }
+  -> sonarqube::move_to_home { 'extensions': }
+  -> sonarqube::move_to_home { 'logs': }
+  # ===== Install SonarQube =====
+  -> exec { 'untar':
+    command => "unzip -o ${tmpzip} -d ${installroot} && chown -R ${user}:${group} ${installroot}/${package_name}-${version} && chown -R ${user}:${group} ${real_home}",
+    creates => "${installroot}/${package_name}-${version}/bin",
+    notify  => Service['sonarqube'],
+  }
+  -> file { $script:
+    mode    => '0755',
+    content => template('sonarqube/sonar.sh.erb'),
+  }
+  -> file { "/etc/init.d/${service}":
+    ensure => link,
+    target => $script,
+  }
+
+  file { '/tmp/cleanup-old-plugin-versions.sh':
+    content => template("${module_name}/cleanup-old-plugin-versions.sh.erb"),
+    mode    => '0755',
+  }
+  -> file { '/tmp/cleanup-old-sonarqube-versions.sh':
+    content => template("${module_name}/cleanup-old-sonarqube-versions.sh.erb"),
+    mode    => '0755',
+  }
+  -> exec { 'remove-old-versions-of-sonarqube':
+    command     => "/tmp/cleanup-old-sonarqube-versions.sh ${installroot} ${version}",
+    path        => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
+    refreshonly => true,
+    subscribe   => File["${installroot}/${package_name}-${version}"],
+  }
+
+  # The plugins directory. Useful to later reference it from the plugin definition
+  file { $plugin_dir:
+    ensure => directory,
+  }
+
+}

--- a/manifests/install/source.pp
+++ b/manifests/install/source.pp
@@ -28,7 +28,7 @@ class sonarqube::install::source {
   }
 
   # wget from https://github.com/maestrodev/puppet-wget
-  include wget
+  include ::wget
 
   Sonarqube::Move_to_home {
     home => $real_home,
@@ -74,7 +74,14 @@ class sonarqube::install::source {
   -> sonarqube::move_to_home { 'logs': }
   # ===== Install SonarQube =====
   -> exec { 'untar':
-    command => "unzip -o ${tmpzip} -d ${installroot} && chown -R ${user}:${group} ${installroot}/${package_name}-${version} && chown -R ${user}:${group} ${real_home}",
+    command => join(
+      [
+        "unzip -o ${tmpzip} -d ${installroot}",
+        "chown -R ${user}:${group} ${installroot}/${package_name}-${version}",
+        "chown -R ${user}:${group} ${real_home}",
+      ],
+      ' && '
+    ),
     creates => "${installroot}/${package_name}-${version}/bin",
     notify  => Service['sonarqube'],
   }

--- a/manifests/move_to_home.pp
+++ b/manifests/move_to_home.pp
@@ -5,8 +5,7 @@ define sonarqube::move_to_home (
   file { "${home}/${name}":
     ensure => directory,
   }
-  ->
-  file { "${sonarqube::installdir}/${name}":
+  -> file { "${sonarqube::installdir}/${name}":
     ensure => link,
     target => "${home}/${name}",
   }

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -36,14 +36,12 @@ define sonarqube::plugin(
       before     => File[$plugin],
       require    => File[$sonarqube::plugin_dir],
     }
-    ~>
-    exec { "remove-old-versions-of-${artifactid}":
+    ~> exec { "remove-old-versions-of-${artifactid}":
       command     => "/tmp/cleanup-old-plugin-versions.sh ${sonarqube::plugin_dir} ${artifactid} ${version}",
       path        => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
       refreshonly => true,
     }
-    ->
-    file { $plugin:
+    -> file { $plugin:
       ensure => $ensure,
       source => "/tmp/${plugin_name}",
       owner  => $sonarqube::user,

--- a/manifests/plugin.pp
+++ b/manifests/plugin.pp
@@ -18,41 +18,24 @@
 #
 define sonarqube::plugin(
   $version,
-  $ensure     = present,
-  $artifactid = $name,
-  $groupid    = 'org.codehaus.sonar-plugins',
+  $ensure       = present,
+  $artifactid   = $name,
+  $groupid      = 'org.codehaus.sonar-plugins',
+  $use_packages = false,
 ) {
-  $plugin_name = "${artifactid}-${version}.jar"
-  $plugin      = "${sonarqube::plugin_dir}/${plugin_name}"
 
-  # Install plugin
-  if $ensure == present {
-    # copy to a temp file as Maven can run as a different user and not have rights to copy to
-    # sonar plugin folder
-    maven { "/tmp/${plugin_name}":
-      groupid    => $groupid,
-      artifactid => $artifactid,
-      version    => $version,
-      before     => File[$plugin],
-      require    => File[$sonarqube::plugin_dir],
-    }
-    ~> exec { "remove-old-versions-of-${artifactid}":
-      command     => "/tmp/cleanup-old-plugin-versions.sh ${sonarqube::plugin_dir} ${artifactid} ${version}",
-      path        => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
-      refreshonly => true,
-    }
-    -> file { $plugin:
-      ensure => $ensure,
-      source => "/tmp/${plugin_name}",
-      owner  => $sonarqube::user,
-      group  => $sonarqube::group,
-      notify => Service['sonarqube'],
-    }
-  } else {
-    # Uninstall plugin if absent
-    file { $plugin:
-      ensure => $ensure,
-      notify => Service['sonarqube'],
+  if $use_packages {
+    ::sonarqube::plugin::package{ $name:
+      ensure  => $ensure,
+      version => $version,
     }
   }
+  else {
+    ::sonarqube::plugin::source{ $name:
+      ensure  => $ensure,
+      version => $version,
+      groupid => $groupid,
+    }
+  }
+
 }

--- a/manifests/plugin/package.pp
+++ b/manifests/plugin/package.pp
@@ -1,0 +1,21 @@
+# install plugin from package
+define sonarqube::plugin::package(
+  $version,
+  $ensure,
+) {
+
+  assert_private()
+
+  # Install plugin
+  if $ensure == present {
+    package{ $name:
+      ensure => $version,
+    }
+  } else {
+    # Uninstall plugin if absent
+    package { $name:
+      ensure => $ensure,
+    }
+  }
+
+}

--- a/manifests/plugin/source.pp
+++ b/manifests/plugin/source.pp
@@ -1,0 +1,43 @@
+# install plugin from source
+define sonarqube::plugin::source(
+  $version,
+  $ensure,
+  $groupid,
+) {
+
+  assert_private()
+
+  $plugin_name = "${name}-${version}.jar"
+  $plugin      = "${sonarqube::plugin_dir}/${plugin_name}"
+  # Install plugin
+  if $ensure == present {
+    # copy to a temp file as Maven can run as a different
+    # user and not have rights to copy to sonar plugin folder
+    maven { "/tmp/${plugin_name}":
+      groupid    => $groupid,
+      artifactid => $name,
+      version    => $version,
+      before     => File[$plugin],
+      require    => File[$sonarqube::plugin_dir],
+    }
+    ~> exec { "remove-old-versions-of-${name}":
+      command     => "/tmp/cleanup-old-plugin-versions.sh ${sonarqube::plugin_dir} ${name} ${version}",
+      path        => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
+      refreshonly => true,
+    }
+    -> file { $plugin:
+      ensure => $ensure,
+      source => "/tmp/${plugin_name}",
+      owner  => $sonarqube::user,
+      group  => $sonarqube::group,
+      notify => Service[$sonarqube::service],
+    }
+  } else {
+    # Uninstall plugin if absent
+    file { $plugin:
+      ensure => $ensure,
+      notify => Service[$sonarqube::service],
+    }
+  }
+
+}

--- a/manifests/runner.pp
+++ b/manifests/runner.pp
@@ -20,19 +20,19 @@ class sonarqube::runner (
     path => '/usr/bin:/usr/sbin:/bin:/sbin:/usr/local/bin',
   }
 
-  anchor { 'sonarqube::runner::begin': } ->
-  class { '::sonarqube::runner::install':
+  anchor { 'sonarqube::runner::begin': }
+  -> class { '::sonarqube::runner::install':
     package_name => $package_name,
     version      => $version,
     download_url => $download_url,
     installroot  => $installroot,
-  } ->
-  class { '::sonarqube::runner::config':
+  }
+  -> class { '::sonarqube::runner::config':
     package_name     => $package_name,
     version          => $version,
     installroot      => $installroot,
     jdbc             => $jdbc,
     sonarqube_server => $sonarqube_server,
-  } ~>
-  anchor { 'sonarqube::runner::end': }
+  }
+  ~> anchor { 'sonarqube::runner::end': }
 }

--- a/manifests/runner/install.pp
+++ b/manifests/runner/install.pp
@@ -5,7 +5,7 @@ class sonarqube::runner::install (
   $download_url,
   $installroot,
 ) {
-  include wget
+  include ::wget
 
   if ! defined(Package[unzip]) {
     package { 'unzip':
@@ -19,18 +19,15 @@ class sonarqube::runner::install (
   wget::fetch { 'download-sonar-runner':
     source      => "${download_url}/${version}/sonar-runner-dist-${version}.zip",
     destination => $tmpzip,
-  } ->
-
-  file { "${installroot}/${package_name}-${version}":
+  }
+  -> file { "${installroot}/${package_name}-${version}":
     ensure => directory,
-  } ->
-
-  file { "${installroot}/${package_name}":
+  }
+  -> file { "${installroot}/${package_name}":
     ensure => link,
     target => "${installroot}/${package_name}-${version}",
-  } ->
-
-  exec { 'unzip-sonar-runner':
+  }
+  -> exec { 'unzip-sonar-runner':
     command => "unzip -o ${tmpzip} -d ${installroot}",
     creates => "${installroot}/sonar-runner-${version}/bin",
     require => [Package[unzip], Wget::Fetch['download-sonar-runner']],

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,0 +1,17 @@
+# manage sonarqube service
+class sonarqube::service {
+
+  # this class intended to be used from main sonarqube class
+  assert_private()
+
+  $service = $::sonarqube::service
+
+  service { 'sonarqube':
+    ensure     => running,
+    name       => $service,
+    hasrestart => true,
+    hasstatus  => true,
+    enable     => true,
+  }
+
+}

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -17,8 +17,7 @@ class sonarqube::user {
       managehome => false,
       system     => $user_system,
     }
-    ->
-    group { $group:
+    -> group { $group:
       ensure => present,
       system => $user_system,
     }

--- a/manifests/user.pp
+++ b/manifests/user.pp
@@ -1,0 +1,27 @@
+# manage the sonar user, if required
+class sonarqube::user {
+
+  # this class intended to be used from sonarqube::install class
+  assert_private()
+
+  $group        = $::sonarqube::group
+  $manage_user  = $::sonarqube::manage_user
+  $real_home    = $::sonarqube::real_home
+  $user         = $::sonarqube::user
+  $user_system  = $::sonarqube::user_system
+
+  if $manage_user {
+    user { $user:
+      ensure     => present,
+      home       => $real_home,
+      managehome => false,
+      system     => $user_system,
+    }
+    ->
+    group { $group:
+      ensure => present,
+      system => $user_system,
+    }
+  }
+
+}

--- a/metadata.json
+++ b/metadata.json
@@ -119,12 +119,8 @@
   ],
   "requirements": [
     {
-      "name": "pe",
-      "version_requirement": ">=3.2.0"
-    },
-    {
       "name": "puppet",
-      "version_requirement": ">=2.7.17"
+      "version_requirement": ">=3.8.7"
     }
   ]
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -2,83 +2,90 @@ require 'spec_helper'
 
 describe 'sonarqube' do
 
-  let(:sonar_properties) { '/usr/local/sonar/conf/sonar.properties' }
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+      let(:sonar_properties) { '/usr/local/sonar/conf/sonar.properties' }
 
-  context "when installing version 4", :compile do
-    let(:params) {{ :version => '4.5.5' }}
-    it { should contain_wget__fetch('download-sonar').with_source('https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-4.5.5.zip') }
-  end
+      context "when installing version 4", :compile do
+        let(:params) {{ :version => '4.5.5' }}
+        it { should contain_wget__fetch('download-sonar').with_source('https://sonarsource.bintray.com/Distribution/sonarqube/sonarqube-4.5.5.zip') }
+      end
 
-  context "when crowd configuration is supplied", :compile do
-    let(:params) { { :crowd => {
-      'application' => 'crowdapplication',
-      'service_url' => 'crowdserviceurl',
-      'password'    => 'crowdpassword',
-    } } }
+      context "when crowd configuration is supplied", :compile do
+        let(:params) { { :crowd => {
+          'application' => 'crowdapplication',
+          'service_url' => 'crowdserviceurl',
+          'password'    => 'crowdpassword',
+        } } }
 
-    it 'should generate sonar.properties config for crowd' do
-      should contain_file(sonar_properties).with_content(%r[sonar\.authenticator\.class: org\.sonar\.plugins\.crowd\.CrowdAuthenticator])
-      should contain_file(sonar_properties).with_content(%r[crowd\.url: crowdserviceurl])
-      should contain_file(sonar_properties).with_content(%r[crowd\.application: crowdapplication])
-      should contain_file(sonar_properties).with_content(%r[crowd\.password: crowdpassword])
+        it 'should generate sonar.properties config for crowd' do
+          should contain_file(sonar_properties).with_content(%r[sonar\.authenticator\.class: org\.sonar\.plugins\.crowd\.CrowdAuthenticator])
+          should contain_file(sonar_properties).with_content(%r[crowd\.url: crowdserviceurl])
+          should contain_file(sonar_properties).with_content(%r[crowd\.application: crowdapplication])
+          should contain_file(sonar_properties).with_content(%r[crowd\.password: crowdpassword])
+        end
+      end
+
+      context "when no crowd configuration is supplied", :compile do
+        it { should contain_file(sonar_properties).without_content("crowd") }
+      end
+
+      context "when unzip package is not defined", :compile do
+        it { should contain_package('unzip').with_ensure('present') }
+      end
+
+      context "when unzip package is already defined", :compile do
+        let(:pre_condition) { %Q[
+          package { 'unzip': ensure => installed }
+        ] }
+
+        it { should contain_package('unzip').with_ensure('installed') }
+      end
+
+      context "when ldap local users configuration is supplied", :compile do
+        let(:params) { { :ldap => {
+          'url'          => 'ldap://myserver.mycompany.com',
+          'user_base_dn' => 'ou=Users,dc=mycompany,dc=com',
+          'local_users'  => 'foo',
+        } } }
+
+        it { should contain_file(sonar_properties).with_content(/sonar.security.localUsers=foo/) }
+        it { should contain_file(sonar_properties).with_content(/sonar.security.realm=LDAP/) }
+        it { should contain_file(sonar_properties).with_content(/ldap.url=ldap:\/\/myserver.mycompany.com/) }
+        it { should contain_file(sonar_properties).with_content(/ldap.user.baseDn: ou=Users,dc=mycompany,dc=com/) }
+      end
+
+      context "when ldap local users configuration is supplied as array", :compile do
+        let(:params) { { :ldap => {
+          'url'          => 'ldap://myserver.mycompany.com',
+          'user_base_dn' => 'ou=Users,dc=mycompany,dc=com',
+          'local_users' => ['foo','bar'],
+        } } }
+
+        it { should contain_file(sonar_properties).with_content(/sonar.security.localUsers=foo,bar/) }
+        it { should contain_file(sonar_properties).with_content(/sonar.security.realm=LDAP/) }
+        it { should contain_file(sonar_properties).with_content(/ldap.url=ldap:\/\/myserver.mycompany.com/) }
+        it { should contain_file(sonar_properties).with_content(/ldap.user.baseDn: ou=Users,dc=mycompany,dc=com/) }
+      end
+
+      context "when no ldap local users configuration is supplied", :compile do
+        let(:params) { { :ldap => {
+          'url'          => 'ldap://myserver.mycompany.com',
+          'user_base_dn' => 'ou=Users,dc=mycompany,dc=com',
+        } } }
+        it { should contain_file(sonar_properties).without_content(/sonar.security.localUsers/) }
+        it { should contain_file(sonar_properties).with_content(/sonar.security.realm=LDAP/) }
+        it { should contain_file(sonar_properties).with_content(/ldap.url=ldap:\/\/myserver.mycompany.com/) }
+        it { should contain_file(sonar_properties).with_content(/ldap.user.baseDn: ou=Users,dc=mycompany,dc=com/) }
+      end
+
+      context "when no ldap configuration is supplied", :compile do
+        it { should contain_file(sonar_properties).without_content(/sonar.security/) }
+        it { should contain_file(sonar_properties).without_content(/ldap./) }
+      end
     end
-  end
-
-  context "when no crowd configuration is supplied", :compile do
-    it { should contain_file(sonar_properties).without_content("crowd") }
-  end
-
-  context "when unzip package is not defined", :compile do
-    it { should contain_package('unzip').with_ensure('present') }
-  end
-
-  context "when unzip package is already defined", :compile do
-    let(:pre_condition) { %Q[
-      package { 'unzip': ensure => installed }
-    ] }
-
-    it { should contain_package('unzip').with_ensure('installed') }
-  end
-
-  context "when ldap local users configuration is supplied", :compile do
-    let(:params) { { :ldap => {
-      'url'          => 'ldap://myserver.mycompany.com',
-      'user_base_dn' => 'ou=Users,dc=mycompany,dc=com',
-      'local_users'  => 'foo',
-    } } }
-
-    it { should contain_file(sonar_properties).with_content(/sonar.security.localUsers=foo/) }
-    it { should contain_file(sonar_properties).with_content(/sonar.security.realm=LDAP/) }
-    it { should contain_file(sonar_properties).with_content(/ldap.url=ldap:\/\/myserver.mycompany.com/) }
-    it { should contain_file(sonar_properties).with_content(/ldap.user.baseDn: ou=Users,dc=mycompany,dc=com/) }
-  end
-
-  context "when ldap local users configuration is supplied as array", :compile do
-    let(:params) { { :ldap => {
-      'url'          => 'ldap://myserver.mycompany.com',
-      'user_base_dn' => 'ou=Users,dc=mycompany,dc=com',
-      'local_users' => ['foo','bar'],
-    } } }
-
-    it { should contain_file(sonar_properties).with_content(/sonar.security.localUsers=foo,bar/) }
-    it { should contain_file(sonar_properties).with_content(/sonar.security.realm=LDAP/) }
-    it { should contain_file(sonar_properties).with_content(/ldap.url=ldap:\/\/myserver.mycompany.com/) }
-    it { should contain_file(sonar_properties).with_content(/ldap.user.baseDn: ou=Users,dc=mycompany,dc=com/) }
-  end
-
-  context "when no ldap local users configuration is supplied", :compile do
-    let(:params) { { :ldap => {
-      'url'          => 'ldap://myserver.mycompany.com',
-      'user_base_dn' => 'ou=Users,dc=mycompany,dc=com',
-    } } }
-    it { should contain_file(sonar_properties).without_content(/sonar.security.localUsers/) }
-    it { should contain_file(sonar_properties).with_content(/sonar.security.realm=LDAP/) }
-    it { should contain_file(sonar_properties).with_content(/ldap.url=ldap:\/\/myserver.mycompany.com/) }
-    it { should contain_file(sonar_properties).with_content(/ldap.user.baseDn: ou=Users,dc=mycompany,dc=com/) }
-  end
-
-  context "when no ldap configuration is supplied", :compile do
-    it { should contain_file(sonar_properties).without_content(/sonar.security/) }
-    it { should contain_file(sonar_properties).without_content(/ldap./) }
   end
 end

--- a/spec/classes/runner_config_spec.rb
+++ b/spec/classes/runner_config_spec.rb
@@ -1,18 +1,25 @@
 require 'spec_helper'
 
 describe 'sonarqube::runner::config' do
-  let(:params) {{
-    :package_name => 'sonar-runner',
-    :version => '2.4',
-    :installroot => '/usr/local',
-    :jdbc => {
-      'url'      => 'jdbc:h2:tcp://localhost:9092/sonar',
-      'username' => 'sonar',
-      'password' => 'sonar',
-    },
-  }}
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+      let(:params) {{
+        :package_name => 'sonar-runner',
+        :version => '2.4',
+        :installroot => '/usr/local',
+        :jdbc => {
+          'url'      => 'jdbc:h2:tcp://localhost:9092/sonar',
+          'username' => 'sonar',
+          'password' => 'sonar',
+        },
+      }}
 
-  context "check properties file" do
-    it { should contain_file('/usr/local/sonar-runner-2.4/conf/sonar-runner.properties') }
+      context "check properties file" do
+        it { should contain_file('/usr/local/sonar-runner-2.4/conf/sonar-runner.properties') }
+      end
+    end
   end
 end

--- a/spec/classes/runner_install_spec.rb
+++ b/spec/classes/runner_install_spec.rb
@@ -1,22 +1,29 @@
 require 'spec_helper'
 
 describe 'sonarqube::runner::install' do
-  let(:params) {{
-    :package_name => 'sonar-runner',
-    :version => '2.4',
-    :download_url => 'http://repo1.maven.org/maven2/org/codehaus/sonar/runner/sonar-runner-dist',
-    :installroot => '/usr/local',
-  }}
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+      let(:params) {{
+        :package_name => 'sonar-runner',
+        :version => '2.4',
+        :download_url => 'http://repo1.maven.org/maven2/org/codehaus/sonar/runner/sonar-runner-dist',
+        :installroot => '/usr/local',
+      }}
 
-  context "contain wget" do
-    it { should contain_class('wget') }
-  end
+      context "contain wget" do
+        it { should contain_class('wget') }
+      end
 
-  context "when installing version 2.4" do
-    it { should contain_wget__fetch('download-sonar-runner').with_source('http://repo1.maven.org/maven2/org/codehaus/sonar/runner/sonar-runner-dist/2.4/sonar-runner-dist-2.4.zip') }
-  end
+      context "when installing version 2.4" do
+        it { should contain_wget__fetch('download-sonar-runner').with_source('http://repo1.maven.org/maven2/org/codehaus/sonar/runner/sonar-runner-dist/2.4/sonar-runner-dist-2.4.zip') }
+      end
 
-  context "check directory link" do
-    it { should contain_file('/usr/local/sonar-runner') }
+      context "check directory link" do
+        it { should contain_file('/usr/local/sonar-runner') }
+      end
+    end
   end
 end

--- a/spec/classes/runner_spec.rb
+++ b/spec/classes/runner_spec.rb
@@ -1,8 +1,15 @@
 require 'spec_helper'
 
 describe 'sonarqube::runner' do
-  context 'when installing' do
-    it { should create_class('sonarqube::runner::install') }
-    it { should create_class('sonarqube::runner::config') }
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+      context 'when installing' do
+        it { should create_class('sonarqube::runner::install') }
+        it { should create_class('sonarqube::runner::config') }
+      end
+    end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,30 +2,25 @@
 #   https://github.com/maestrodev/puppet-modulesync
 
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+
+include RspecPuppetFacts
+add_custom_fact :http_proxy, nil
+
+require 'simplecov'
+require 'simplecov-console'
+
+SimpleCov.start do
+  add_filter '/spec'
+  add_filter '/vendor'
+  formatter SimpleCov::Formatter::MultiFormatter.new([
+    SimpleCov::Formatter::HTMLFormatter,
+    SimpleCov::Formatter::Console
+  ])
+end
 
 RSpec.configure do |c|
-  c.treat_symbols_as_metadata_keys_with_true_values = true
-  c.mock_with :rspec
   c.hiera_config = File.expand_path(File.join(__FILE__, '../fixtures/hiera.yaml'))
-
-  c.before(:each) do
-    Puppet::Util::Log.level = :warning
-    Puppet::Util::Log.newdestination(:console)
-  end
-
-  c.default_facts = {
-    :operatingsystem => 'CentOS',
-    :operatingsystemrelease => '6.6',
-    :kernel => 'Linux',
-    :osfamily => 'RedHat',
-    :architecture => 'x86_64',
-    :clientcert => 'puppet.acme.com'
-  }.merge({"http_proxy"=>nil, "maven_version"=>"3.0.5"})
-
-  c.before do
-    # avoid "Only root can execute commands as other users"
-    Puppet.features.stubs(:root? => true)
-  end
 end
 
 shared_examples :compile, :compile => true do

--- a/templates/sonar.properties.erb
+++ b/templates/sonar.properties.erb
@@ -153,7 +153,7 @@ sonar.jdbc.password:    <%= @jdbc['password'] %>
 # directory containing H2 database files. By default it's the /data directory in the SonarQube installation.
 #sonar.embeddedDatabase.dataDir:
 # H2 embedded database server listening port, defaults to 9092
-#sonar.embeddedDatabase.port:               9092
+sonar.embeddedDatabase.port:               9092
 
 
 #----- MySQL 5.x

--- a/templates/sonar.properties.erb
+++ b/templates/sonar.properties.erb
@@ -153,7 +153,7 @@ sonar.jdbc.password:    <%= @jdbc['password'] %>
 # directory containing H2 database files. By default it's the /data directory in the SonarQube installation.
 #sonar.embeddedDatabase.dataDir:
 # H2 embedded database server listening port, defaults to 9092
-sonar.embeddedDatabase.port:               9092
+#sonar.embeddedDatabase.port:               9092
 
 
 #----- MySQL 5.x

--- a/templates/sonar.service.erb
+++ b/templates/sonar.service.erb
@@ -1,0 +1,16 @@
+[Unit]
+Description=Sonar
+After=network.target network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=<%= @sonar_script %> start
+ExecStop=<%= @sonar_script %> stop
+ExecReload=<%= @sonar_script %> restart
+PIDFile=<%= $pid_file %>
+Type=forking
+User=<%= @user %>
+
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
These changes all started as I wanted to install sonar from OS packages (RPMs on EL7, specifically).

In simple terms, I've added a parameter `use_packages` which is `false` by default. If set `true`, the module will install sonarqube from an OS package. If `false`, it will use your code to install from source.

I've also updated the test configuration to work on later versions of puppet + ruby, and use rspec-puppet-facts.

I'm submitting this as a PR not because it's ready to accept, but so you get some visibility and can offer feedback :)

Individual commit messages:

- Refactor to allow install from OS package
- Use "version" parameter rather than separate package_version
- Make user creation optional
- Symlink sonar.sh into /etc/init.d
- Enable embeddedDatabase port paramter in config (service won't start without it)
- Revert "Symlink sonar.sh into /etc/init.d"
- Add systemd service file
- Notify service if install changes
- Notify the daemon-reload exec
- Don't remove the init script installed by the RPM
- Only install systemd unit file on systems that use systemd
- Open firewall ports, if requested
- Add safe_yaml gem to make this work with puppet 3.x on ruby >= 2.2
- Bump stdlib version
- Fix duplicate declaration, and cleanup for puppet lint
- update to more recent test helpers - fixes a lot of warnings
- Update spec_helper and use rspec-puppet-facts