### PR TITLE
Managing compute engine heap

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,6 +47,7 @@ class sonarqube (
   $http_proxy       = {},
   $profile          = false,
   $web_java_opts    = undef,
+  $ce_java_opts     = undef,
   $search_java_opts = undef,
   $search_host      = '127.0.0.1',
   $search_port      = '9001',

--- a/templates/sonar.properties.erb
+++ b/templates/sonar.properties.erb
@@ -41,6 +41,10 @@ sonar.web.context:                        <%= @context_path %>
 sonar.web.javaOpts=<%= @web_java_opts %>
 <% end -%>
 
+<% if @ce_java_opts -%>
+sonar.ce.javaOpts=<%= @ce_java_opts %>
+<% end -%>
+
 <% if !@https.empty? -%>
 #-------------------
 # SonarQube Https Configuration


### PR DESCRIPTION
As documented here:
https://docs.sonarqube.org/display/SONAR/Java+Process+Memory

This is just simply enabling setting heap parameters for CE heap (for web and ES it was already there). 