### PR TITLE
Added support for new commercial edition download.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ before_install:
   - rm -f Gemfile.lock
 
 rvm:
-  - "2.0.0"
+  - "2.1.8"
 
 env:
   - PUPPET_VERSION="~> 3.7.0"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ or
     class { 'sonarqube':
       arch          => 'linux-x86-64',
       version       => '5.1,
+      edition       => 'community',
       user          => 'sonar',
       group         => 'sonar',
       service       => 'sonar',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,6 +13,7 @@
 # limitations under the License.
 class sonarqube (
   $version          = '4.5.5',
+  $edition          = 'community',
   $user             = 'sonar',
   $group            = 'sonar',
   $user_system      = true,
@@ -82,6 +83,12 @@ class sonarqube (
   $tmpzip = "${download_dir}/${package_name}-${version}.zip"
   $script = "${installdir}/bin/${arch}/sonar.sh"
 
+  if $edition == 'community' {
+    $source_url = "${download_url}/${package_name}-${version}.zip"
+  } else {
+    $source_url = "${download_url}/${package_name}-${edition}-${version}.zip"
+  }
+
   if ! defined(Package[unzip]) {
     package { 'unzip':
       ensure => present,
@@ -102,7 +109,7 @@ class sonarqube (
   }
   ->
   wget::fetch { 'download-sonar':
-    source      => "${download_url}/${package_name}-${version}.zip",
+    source      => "${source_url}",
     destination => $tmpzip,
   }
   ->


### PR DESCRIPTION
Sonar 7 has changed the download links for different editions. This PR adds the option for user to manage community and commercial Sonar via Puppet.

For example, in my case I need developer edition:
```
download_url: 'https://sonarsource.bintray.com/CommercialDistribution/sonarqube-developer'
edition: 'developer'
version: '7.2.1'
```