### PR TITLE
 Switch download url from bintray to binaries.sonarsource.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ or
       service       => 'sonar',
       installroot   => '/usr/local',
       home          => '/var/local/sonar',
-      download_url  => 'https://sonarsource.bintray.com/Distribution/sonarqube'
+      download_url  => 'https://binaries.sonarsource.com/Distribution/sonarqube'
       jdbc          => $jdbc,
       web_java_opts => '-Xmx1024m',
       log_folder    => '/var/local/sonar/logs',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,7 +22,7 @@ class sonarqube (
   $host             = undef,
   $port             = 9000,
   $portAjp          = -1,
-  $download_url     = 'https://sonarsource.bintray.com/Distribution/sonarqube',
+  $download_url     = 'https://binaries.sonarsource.com/Distribution/sonarqube',
   $download_dir     = '/usr/local/src',
   $context_path     = '/',
   $arch             = $sonarqube::params::arch,


### PR DESCRIPTION
As you can see on https://www.sonarqube.org/downloads/, we (I'm working at SonarSource, the company behind SonarQube) decided to switch from bintray to our own download site.